### PR TITLE
Fix Docker start up.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ENV PATH /edx/app/node_modules/.bin:$PATH
 WORKDIR /edx/app
 COPY . /edx/app
 
-CMD [ "npm", "run", "start" ]
+ENTRYPOINT npm install && npm run start


### PR DESCRIPTION
This brings this repo inline with https://github.com/edx/front-end-cookie-cutter-application/blob/master/Dockerfile#L29 and enables `docker up` to work.