### PR TITLE
ENT-1051 Use webpack EnvironmentPlugin for configuration variables

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -2,6 +2,7 @@
 // time at the expense of creating larger, unoptimized bundles.
 const Merge = require('webpack-merge');
 const path = require('path');
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const commonConfig = require('./webpack.common.config.js');
@@ -94,6 +95,11 @@ module.exports = Merge.smart(commonConfig, {
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(__dirname, '../public/index.html'),
       favicon: path.resolve(__dirname, '../src/images/favicon.ico'),
+    }),
+    new webpack.EnvironmentPlugin({
+      NODE_ENV: 'development',
+      LMS_BASE_URL: 'http://localhost:18000',
+      DATA_API_BASE_URL: 'http://localhost:8000',
     }),
   ],
   // This configures webpack-dev-server which serves bundles from memory and provides live

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -3,6 +3,7 @@
 const Merge = require('webpack-merge');
 const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
+const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
@@ -120,6 +121,12 @@ module.exports = Merge.smart(commonConfig, {
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(__dirname, '../public/index.html'),
       favicon: path.resolve(__dirname, '../src/images/favicon.ico'),
+    }),
+    new webpack.EnvironmentPlugin({
+      // default values of undefined to force definition in the envrionment at build time
+      NODE_ENV: 'production',
+      LMS_BASE_URL: undefined,
+      DATA_API_BASE_URL: undefined,
     }),
   ],
 });

--- a/src/data/services/EnterpriseDataApiService.js
+++ b/src/data/services/EnterpriseDataApiService.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import qs from 'query-string';
 
 class EnterpriseDataApiService {
-  // NOTE: This is pulling from a local instance of the edx-analytics-data-api (https://github.com/edx/edx-analytics-data-api).
-  static baseUrl = 'http://localhost:8000/enterprise/api/v0/enterprise/';
+  // TODO: This should access the data-api through the gateway instead of direct
+  static enterpiseBaseUrl = `${process.env.DATA_API_BASE_URL}/enterprise/api/v0/enterprise/`;
   static jwtToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOiBbInJlYWQiLCAid3JpdGUiLCAicHJvZmlsZSIsICJlbWFpbCJdLCAiYWRtaW5pc3RyYXRvciI6IHRydWUsICJhdWQiOiAibG1zLWtleSIsICJmYW1pbHlfbmFtZSI6ICIiLCAiaXNzIjogImh0dHA6Ly9lZHguZGV2c3RhY2subG1zOjE4MDAwL29hdXRoMiIsICJmaWx0ZXJzIjogWyJ1c2VyOm1lIl0sICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiZWR4IiwgIm5hbWUiOiAiIiwgInZlcnNpb24iOiAiMS4xLjAiLCAiZ2l2ZW5fbmFtZSI6ICIiLCAiZXhwIjogMTUzMjAzNjA0NCwgImlhdCI6IDE1MzIwMDAwNDQsICJpc19yZXN0cmljdGVkIjogZmFsc2UsICJlbWFpbCI6ICJlZHhAZXhhbXBsZS5jb20iLCAic3ViIjogImZjMmI3MjAxMTRiYjA3YjQ2NWU4NDNhNzRlYzY4M2U2In0.vR-rzXqZtOOddfVQ3U7_3pDjjWP1tFA41mEnTSthirg';
 
   static fetchCourseEnrollments(enterpriseId, options) {

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -5,6 +5,7 @@ class LmsApiService {
   // TODO: JWT token currently hardcoded but will be replaced
   // once authentication is implemented.
   static jwtToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOiBbInJlYWQiLCAid3JpdGUiLCAicHJvZmlsZSIsICJlbWFpbCJdLCAiYWRtaW5pc3RyYXRvciI6IHRydWUsICJhdWQiOiAibG1zLWtleSIsICJmYW1pbHlfbmFtZSI6ICIiLCAiaXNzIjogImh0dHA6Ly9lZHguZGV2c3RhY2subG1zOjE4MDAwL29hdXRoMiIsICJmaWx0ZXJzIjogWyJ1c2VyOm1lIl0sICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiZWR4IiwgIm5hbWUiOiAiIiwgInZlcnNpb24iOiAiMS4xLjAiLCAiZ2l2ZW5fbmFtZSI6ICIiLCAiZXhwIjogMTUzMjAzNjA0NCwgImlhdCI6IDE1MzIwMDAwNDQsICJpc19yZXN0cmljdGVkIjogZmFsc2UsICJlbWFpbCI6ICJlZHhAZXhhbXBsZS5jb20iLCAic3ViIjogImZjMmI3MjAxMTRiYjA3YjQ2NWU4NDNhNzRlYzY4M2U2In0.vR-rzXqZtOOddfVQ3U7_3pDjjWP1tFA41mEnTSthirg';
+  static baseUrl = process.env.LMS_BASE_URL;
 
   static fetchCourseOutline(courseId) {
     const options = {
@@ -14,7 +15,7 @@ class LmsApiService {
       nav_depth: 3,
       block_types_filter: 'course,chapter,sequential,vertical',
     };
-    const outlineUrl = `http://localhost:18000/api/courses/v1/blocks/?${qs.stringify(options)}`;
+    const outlineUrl = `${this.baseUrl}/api/courses/v1/blocks/?${qs.stringify(options)}`;
     return axios.get(outlineUrl, {
       withCredentials: true,
       headers: {
@@ -24,8 +25,7 @@ class LmsApiService {
   }
 
   static fetchPortalConfiguration(enterpriseSlug) {
-    // TODO: This should pull from LMS
-    const portalConfigurationUrl = `http://localhost:18000/enterprise/api/v1/enterprise-customer-branding/${enterpriseSlug}/`;
+    const portalConfigurationUrl = `${this.baseUrl}/enterprise/api/v1/enterprise-customer-branding/${enterpriseSlug}/`;
     return axios.get(portalConfigurationUrl, {
       withCredentials: true,
       headers: {


### PR DESCRIPTION
This PR leverages the webpack EnvironmentPlugin to set configuration variables. Currently
only two values are needed:
- LMS_BASE_URL
- DATA_API_BASE_URL

By default values for development are set but the production values are left undefined.
Webpack will throw a warning if the variables are not defined. They can be passed in
through process.env:
```
LMS_BASE_URL=https://courses.edx.org DATA_API_BASE_URL=https://prod-edx-analyticsapi.edx.org npm run build
```

It is worth noting that the create-react-app project does support more complex scenarios with [custom environment variables])https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables) however this project does not include any of the necessary react-scripts to support this. We may want to consider adding in react-scripts or at least [dotenv-webpack](https://github.com/mrsteele/dotenv-webpack) support in the future.