### PR TITLE
Updates the Sign In button to a submit button

### DIFF
--- a/src/components/LoginForm/__snapshots__/LoginForm.test.jsx.snap
+++ b/src/components/LoginForm/__snapshots__/LoginForm.test.jsx.snap
@@ -115,7 +115,7 @@ exports[`<LoginForm /> renders correctly with error state 1`] = `
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
-                    type="button"
+                    type="submit"
                   >
                     Sign In
                   </button>
@@ -260,7 +260,7 @@ exports[`<LoginForm /> renders correctly with inital (non loading) state 1`] = `
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
-                    type="button"
+                    type="submit"
                   >
                     Sign In
                   </button>
@@ -396,7 +396,7 @@ exports[`<LoginForm /> renders correctly with loading state 1`] = `
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
-                    type="button"
+                    type="submit"
                   >
                     Sign In
                   </button>

--- a/src/components/LoginForm/index.jsx
+++ b/src/components/LoginForm/index.jsx
@@ -90,7 +90,7 @@ class LoginForm extends React.Component {
                 <div className="form-addons">
                   <div className="row">
                     <div className="col-3">
-                      <Button buttonType="primary" label="Sign In" onClick={this.handleSubmit} />
+                      <Button buttonType="primary" label="Sign In" type="submit" onClick={this.handleSubmit} />
                     </div>
                     <div className="ml-2">
                       <LoadingSpinner loading={loading} />


### PR DESCRIPTION
This allows the 'enter' key to be used on any of the form elements to submit the login form. Visually looks exactly the same.