### PR TITLE
Forces all cookies to use path '/' for access from all pages

### DIFF
--- a/src/data/actions/authentication.js
+++ b/src/data/actions/authentication.js
@@ -37,7 +37,10 @@ const login = (email, password) => (
         cookies.set(
           cookieName,
           response.data.access_token,
-          { secure: configuration.SECURE_COOKIES },
+          {
+            secure: configuration.SECURE_COOKIES,
+            path: '/',
+          },
         );
         dispatch(fetchLoginSuccess(email));
       })

--- a/src/data/actions/authentication.test.js
+++ b/src/data/actions/authentication.test.js
@@ -70,7 +70,10 @@ describe('actions', () => {
         expect(mockCookies.set).toHaveBeenCalledWith(
           'access_token',
           responseData.access_token,
-          { secure: true },
+          {
+            secure: true,
+            path: '/',
+          },
         );
       });
     });


### PR DESCRIPTION
This was manifesting itself as two odd bugs - sometimes the email address
was not being loaded because the cookie could not be read, therefore the
dropdown was not being shown. It was also causing an issue where when logging
out the cookie wasn't actually removed since the path didnt match when
calling cookies.remove