### PR TITLE
react-spinners requires 'emotion' to be included as a babel plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,6 +12,7 @@
   ],
   "plugins": [
     "transform-object-rest-spread",
-    "transform-class-properties"
+    "transform-class-properties",
+    "emotion"
   ]
 }


### PR DESCRIPTION
This was resulting in a very odd bug in our prod builds where after
fetching the enterprise list this error would be displayed:
>"TypeError: Cannot set property 'getCurrentStack' of undefined"

As the react-spinners documentation points out:
> IMPORTANT: This package uses emotion. Remember to add the plugin to .babelrc