### PR TITLE
Ensure the user is read from the cookie when loading the enterprise list

### DIFF
--- a/src/components/EnterpriseList/EnterpriseList.test.jsx
+++ b/src/components/EnterpriseList/EnterpriseList.test.jsx
@@ -11,6 +11,7 @@ const EnterpriseListWrapper = props => (
     <EnterpriseList
       getEnterpriseList={() => {}}
       clearPortalConfiguration={() => {}}
+      getLocalUser={() => {}}
       {...props}
     />
   </MemoryRouter>
@@ -20,19 +21,22 @@ describe('<EnterpriseList />', () => {
   let wrapper;
 
   describe('renders correctly', () => {
-    it('calls getEnterpriseList and clearPortalConfiguration props', () => {
+    it('calls getEnterpriseList, clearPortalConfiguration and getLocalUser props', () => {
       const mockGetEnterpriseList = jest.fn();
       const mockClearPortalConfiguration = jest.fn();
+      const mockGetLocalUser = jest.fn();
       const tree = renderer
         .create((
           <EnterpriseListWrapper
             getEnterpriseList={mockGetEnterpriseList}
             clearPortalConfiguration={mockClearPortalConfiguration}
+            getLocalUser={mockGetLocalUser}
           />
         ))
         .toJSON();
       expect(mockGetEnterpriseList).toHaveBeenCalled();
       expect(mockClearPortalConfiguration).toHaveBeenCalled();
+      expect(mockGetLocalUser).toHaveBeenCalled();
       expect(tree).toMatchSnapshot();
     });
 
@@ -100,6 +104,7 @@ describe('<EnterpriseList />', () => {
             enterprises={oneEnterpriseListData}
             getEnterpriseList={() => {}}
             clearPortalConfiguration={() => {}}
+            getLocalUser={() => {}}
           />
         </MemoryRouter>
       ));

--- a/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
+++ b/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<EnterpriseList /> renders correctly calls getEnterpriseList and clearPortalConfiguration props 1`] = `
+exports[`<EnterpriseList /> renders correctly calls getEnterpriseList, clearPortalConfiguration and getLocalUser props 1`] = `
 <div>
   <div
     className="container"

--- a/src/components/EnterpriseList/index.jsx
+++ b/src/components/EnterpriseList/index.jsx
@@ -31,6 +31,7 @@ class EnterpriseList extends React.Component {
   componentDidMount() {
     this.clearPortalConfiguration();
     this.getEnterpriseList();
+    this.props.getLocalUser();
   }
 
   componentDidUpdate(prevProps) {
@@ -160,6 +161,7 @@ EnterpriseList.defaultProps = {
 EnterpriseList.propTypes = {
   getEnterpriseList: PropTypes.func.isRequired,
   clearPortalConfiguration: PropTypes.func.isRequired,
+  getLocalUser: PropTypes.func.isRequired,
   enterprises: PropTypes.shape({
     count: PropTypes.number,
     num_pages: PropTypes.number,

--- a/src/containers/EnterpriseIndexPage/index.jsx
+++ b/src/containers/EnterpriseIndexPage/index.jsx
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import EnterpriseList from '../../components/EnterpriseList';
 import fetchEnterpriseList from '../../data/actions/enterpriseList';
 import { clearPortalConfiguration } from '../../data/actions/portalConfiguration';
+import { getLocalUser } from '../../data/actions/authentication';
 
 const mapStateToProps = state => ({
   loading: state.enterpriseList.loading,
@@ -15,6 +16,9 @@ const mapDispatchToProps = dispatch => ({
   },
   clearPortalConfiguration: () => {
     dispatch(clearPortalConfiguration());
+  },
+  getLocalUser: () => {
+    dispatch(getLocalUser());
   },
 });
 


### PR DESCRIPTION
Unlike the admin dashboard, the enterprise list sits outside the `<App />` therefore
the call to getLocalUser() was never made and the user dropdown was not being shown