### PR TITLE
Dispatch logout action when API calls return 401 or 403 errors

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -100,7 +100,7 @@ module.exports = Merge.smart(commonConfig, {
       NODE_ENV: 'development',
       LMS_BASE_URL: 'http://localhost:18000',
       DATA_API_BASE_URL: 'http://localhost:8000',
-      LMS_CLIENT_ID: '6cb72dc5675a1e7efe81',
+      LMS_CLIENT_ID: 'CMehRRNqfiBRVJKnPOkjBDjAvurtnHpELoehKAvZ',
     }),
   ],
   // This configures webpack-dev-server which serves bundles from memory and provides live

--- a/src/data/services/EnterpriseDataApiService.js
+++ b/src/data/services/EnterpriseDataApiService.js
@@ -1,7 +1,7 @@
-import axios from 'axios';
 import qs from 'query-string';
 
 import config from '../../config';
+import httpClient from '../../httpClient';
 import { getAccessToken } from '../../utils';
 
 class EnterpriseDataApiService {
@@ -17,7 +17,7 @@ class EnterpriseDataApiService {
     const enrollmentsUrl = `${this.enterpriseBaseUrl}${enterpriseId}/enrollments/?${qs.stringify(queryParams)}`;
     const jwtToken = getAccessToken();
 
-    return axios.get(enrollmentsUrl, {
+    return httpClient.get(enrollmentsUrl, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },
@@ -27,7 +27,7 @@ class EnterpriseDataApiService {
   static fetchCourseEnrollmentsCsv(enterpriseId) {
     const csvUrl = `${this.enterpriseBaseUrl}${enterpriseId}/enrollments.csv/?no_page=true`;
     const jwtToken = getAccessToken();
-    return axios.get(csvUrl, {
+    return httpClient.get(csvUrl, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },
@@ -38,7 +38,7 @@ class EnterpriseDataApiService {
     const analyticsUrl = `${this.enterpriseBaseUrl}${enterpriseId}/enrollments/overview/`;
     const jwtToken = getAccessToken();
 
-    return axios.get(analyticsUrl, {
+    return httpClient.get(analyticsUrl, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -1,7 +1,7 @@
-import axios from 'axios';
 import qs from 'query-string';
 
 import configuration from '../../config';
+import httpClient from '../../httpClient';
 import { getAccessToken } from '../../utils';
 
 class LmsApiService {
@@ -20,7 +20,7 @@ class LmsApiService {
     const outlineUrl = `${this.baseUrl}/api/courses/v1/blocks/?${qs.stringify(options)}`;
     const jwtToken = getAccessToken();
 
-    return axios.get(outlineUrl, {
+    return httpClient.get(outlineUrl, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },
@@ -31,7 +31,7 @@ class LmsApiService {
     const portalConfigurationUrl = `${this.baseUrl}/enterprise/api/v1/enterprise-customer-branding/${enterpriseSlug}/`;
     const jwtToken = getAccessToken();
 
-    return axios.get(portalConfigurationUrl, {
+    return httpClient.get(portalConfigurationUrl, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },
@@ -48,7 +48,7 @@ class LmsApiService {
     const enterpriseListUrl = `${this.baseUrl}/enterprise/api/v1/enterprise-customer/with_access_to/?${qs.stringify(queryParams)}`;
     const jwtToken = getAccessToken();
 
-    return axios.get(enterpriseListUrl, {
+    return httpClient.get(enterpriseListUrl, {
       withCredentials: true,
       headers: {
         Authorization: `JWT ${jwtToken}`,
@@ -65,7 +65,7 @@ class LmsApiService {
       token_type: 'jwt',
     };
     const authUrl = `${this.baseUrl}/oauth2/access_token/`;
-    return axios.post(authUrl, qs.stringify(loginData));
+    return httpClient.post(authUrl, qs.stringify(loginData));
   }
 }
 

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+import store from './data/store';
+import { logout } from './data/actions/authentication';
+
+const httpClient = axios;
+
+// Configure axios with response interceptor
+httpClient.interceptors.response.use(response => response, (error) => {
+  const errorStatus = error && error.response && error.response.status;
+  if (errorStatus === 401 || errorStatus === 403) {
+    store.dispatch(logout());
+  }
+  return Promise.reject(error);
+});
+
+export default httpClient;


### PR DESCRIPTION
When an API response returns an error with a status code of 401 (unauthorized) or 403 (forbidden), we should force logout the user so they return to the login page to reset their session.