### PR TITLE
Ensure / route is a PrivateRoute to force login

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -11,7 +11,6 @@ import './Header.scss';
 const Header = (props) => {
   const {
     enterpriseLogo,
-    enterpriseSlug,
     email,
   } = props;
 
@@ -20,7 +19,7 @@ const Header = (props) => {
       <nav className="navbar px-0 justify-content-between">
         <div>
           <Link
-            to={enterpriseSlug ? `/${enterpriseSlug}` : '/'}
+            to="/"
             className="navbar-brand"
           >
             <Img src={enterpriseLogo || EdxLogo} alt="" />
@@ -39,13 +38,11 @@ const Header = (props) => {
 };
 
 Header.propTypes = {
-  enterpriseSlug: PropTypes.string,
   enterpriseLogo: PropTypes.string,
   email: PropTypes.string,
 };
 
 Header.defaultProps = {
-  enterpriseSlug: null,
   enterpriseLogo: null,
   email: null,
 };

--- a/src/containers/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/containers/Header/__snapshots__/Header.test.jsx.snap
@@ -39,7 +39,7 @@ exports[`<Header /> renders enterprise logo correctly 1`] = `
     <div>
       <a
         className="navbar-brand"
-        href="/test-enterprise"
+        href="/"
         onClick={[Function]}
       >
         <img

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -39,9 +39,9 @@ const AppWrapper = () => (
             <Route exact path="/login" component={LoginPage} />
             <Route exact path="/logout" component={LogoutHandler} />
             <Route exact path="/support" component={SupportPage} />
-            <PrivateRoute path="/enterprises" component={EnterpriseIndexPage} />
+            <PrivateRoute exact path="/enterprises" component={EnterpriseIndexPage} />
             <PrivateRoute path="/:enterpriseSlug" component={EnterpriseApp} />
-            <Route exact path="/" component={EnterpriseIndexPage} />
+            <PrivateRoute exact path="/" component={EnterpriseIndexPage} />
             <Route component={NotFoundPage} />
           </Switch>
           <Footer />


### PR DESCRIPTION
Currently, we do not enforce that the `/` route is a `PrivateRoute`. As such, we try to load the `EnterpriseList` which results in a 401 error. The `logout` action is properly dispatched to handle this but the redirect to the `Login` page does not work. 

By making the `/` route a `PrivateRoute`, we ensure that the login page will be shown if logged out.

Also, I updated the enterprise logo link in the `Header` to link to `/` so that clicking on the logo will go back to the `EnterpriseList` (which would redirect back to the dashboard page if there's only one enterprise the user has access to.