### PR TITLE
Fix ErrorPage tests & IE11 CSS issue, rename EnterpriseApp

### DIFF
--- a/src/components/Admin/Admin.scss
+++ b/src/components/Admin/Admin.scss
@@ -4,7 +4,6 @@
 
     > [class*="col-"] {
         display: flex;
-        flex-direction: column;
     }
 
     .card {

--- a/src/containers/EnterpriseApp/index.jsx
+++ b/src/containers/EnterpriseApp/index.jsx
@@ -12,7 +12,7 @@ import ErrorPage from '../ErrorPage';
 import { fetchPortalConfiguration } from '../../data/actions/portalConfiguration';
 import { getLocalUser } from '../../data/actions/authentication';
 
-class App extends React.Component {
+class EnterpriseApp extends React.Component {
   componentDidMount() {
     const { enterpriseSlug } = this.props.match.params;
 
@@ -60,7 +60,7 @@ class App extends React.Component {
   }
 }
 
-App.propTypes = {
+EnterpriseApp.propTypes = {
   getPortalConfiguration: PropTypes.func.isRequired,
   getLocalUser: PropTypes.func.isRequired,
   match: PropTypes.shape({
@@ -73,7 +73,7 @@ App.propTypes = {
   enterpriseId: PropTypes.string,
 };
 
-App.defaultProps = {
+EnterpriseApp.defaultProps = {
   error: null,
   enterpriseId: null,
 };
@@ -92,4 +92,4 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(App);
+export default connect(mapStateToProps, mapDispatchToProps)(EnterpriseApp);

--- a/src/containers/ErrorPage/ErrorPage.test.jsx
+++ b/src/containers/ErrorPage/ErrorPage.test.jsx
@@ -9,7 +9,7 @@ describe('<ErrorPage />', () => {
     const tree = renderer
       .create((
         <MemoryRouter>
-          <ErrorPage status="500" message="Something went terribly wrong" />
+          <ErrorPage status={500} message="Something went terribly wrong" />
         </MemoryRouter>
       ))
       .toJSON();
@@ -20,7 +20,7 @@ describe('<ErrorPage />', () => {
     const tree = renderer
       .create((
         <MemoryRouter>
-          <ErrorPage status="404" message="Not Found" />
+          <ErrorPage status={404} />
         </MemoryRouter>
       ))
       .toJSON();

--- a/src/containers/ErrorPage/__snapshots__/ErrorPage.test.jsx.snap
+++ b/src/containers/ErrorPage/__snapshots__/ErrorPage.test.jsx.snap
@@ -45,38 +45,23 @@ exports[`<ErrorPage /> renders correctly for 404 errors 1`] = `
 <div
   className="container"
 >
-  <div>
+  <div
+    className="container mt-3"
+  >
     <div
-      className="row mt-4"
+      className="text-center py-5"
     >
-      <div
-        className="col"
+      <h1>
+        404
+      </h1>
+      <p
+        className="lead"
       >
-        <h1>
-          Error
-        </h1>
-        <div
-          className="alert fade alert-danger show"
-          hidden={false}
-          role="alert"
-        >
-          <div
-            className="alert-dialog"
-          >
-            <div
-              className=""
-            >
-              <div
-                className="message"
-              >
-                <span>
-                  Not Found
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+        Oops, sorry we can't find that page!
+      </p>
+      <p>
+        Either something went wrong or the page doesn't exist anymore.
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
* In testing IE11 and Edge on Windows, the top 4 boxes on admin dashboard had no height. Removing `flex-direction: column;` fixes the issue so that the height of the boxes are consistent across browsers.
* `<ErrorPage>`'s `status` prop should be a number, but in the tests, we were passing in a string. Modified this and updated the snapshot so that we are actually testing that the `NotFoundPage` renders.
* We renamed `App` to `EnterpriseApp` but didn't update the name of the component within `EnterpriseApp/index.jsx`.