### PR TITLE
Client-side sorting in TableWithPagination for page count < 1

### DIFF
--- a/src/components/CourseEnrollments/CourseEnrollments.test.jsx
+++ b/src/components/CourseEnrollments/CourseEnrollments.test.jsx
@@ -80,29 +80,7 @@ describe('<CourseEnrollments />', () => {
   });
 
   describe('formatEnrollmentData', () => {
-    const expectedData = [{
-      ...mockCourseEnrollments.results[0],
-      course_start: 'September 1, 2016',
-      course_end: 'December 1, 2016',
-      current_grade: '80%',
-      course_price: '$200',
-      has_passed: 'Yes',
-      last_activity_date: 'June 23, 2017',
-      passed_timestamp: 'May 9, 2017',
-      enrollment_created_timestamp: 'June 27, 2014',
-      user_account_creation_timestamp: 'February 12, 2015',
-    }, {
-      ...mockCourseEnrollments.results[1],
-      course_start: 'September 1, 2016',
-      course_end: 'December 1, 2016',
-      current_grade: '',
-      course_price: '$200',
-      has_passed: 'No',
-      last_activity_date: null,
-      passed_timestamp: 'Has not passed',
-      enrollment_created_timestamp: 'June 27, 2014',
-      user_account_creation_timestamp: 'February 12, 2015',
-    }];
+    const expectedData = mockCourseEnrollments.results;
 
     beforeEach(() => {
       wrapper = shallow((

--- a/src/components/CourseEnrollments/index.jsx
+++ b/src/components/CourseEnrollments/index.jsx
@@ -59,11 +59,11 @@ export class CourseEnrollments extends React.Component {
           columnSortable: true,
         },
       ],
-      enrollments: this.formatEnrollmentData(enrollments),
-      pageCount: enrollments ? enrollments.num_pages : null,
+      enrollments: enrollments && enrollments.results,
+      pageCount: enrollments && enrollments.num_pages,
     };
 
-    this.renderTableContent = this.renderTableContent.bind(this);
+    this.formatEnrollmentData = this.formatEnrollmentData.bind(this);
   }
 
   componentDidMount() {
@@ -80,8 +80,8 @@ export class CourseEnrollments extends React.Component {
 
     if (enrollments !== prevProps.enrollments) {
       this.setState({ // eslint-disable-line react/no-did-update-set-state
-        enrollments: this.formatEnrollmentData(enrollments),
-        pageCount: enrollments ? enrollments.num_pages : null,
+        enrollments: enrollments && enrollments.results,
+        pageCount: enrollments && enrollments.num_pages,
       });
     }
 
@@ -105,11 +105,11 @@ export class CourseEnrollments extends React.Component {
   formatEnrollmentData(enrollments) {
     if (!enrollments) {
       return null;
-    } else if (!enrollments.results.length) {
+    } else if (!enrollments.length) {
       return [];
     }
 
-    return enrollments.results.map(enrollment => ({
+    return enrollments.map(enrollment => ({
       ...enrollment,
       last_activity_date: formatTimestamp({ timestamp: enrollment.last_activity_date }),
       course_start: formatTimestamp({ timestamp: enrollment.course_start }),
@@ -165,6 +165,7 @@ export class CourseEnrollments extends React.Component {
         handleDataUpdate={options =>
           this.getCourseEnrollments(this.props.enterpriseId, options)
         }
+        formatData={this.formatEnrollmentData}
       />
     );
   }

--- a/src/components/EnterpriseList/EnterpriseList.test.jsx
+++ b/src/components/EnterpriseList/EnterpriseList.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { Link, MemoryRouter, Redirect } from 'react-router-dom';
+import { MemoryRouter, Redirect } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
 
 import EnterpriseList from './index';
@@ -114,13 +114,7 @@ describe('<EnterpriseList />', () => {
   });
 
   describe('formatEnterpriseData', () => {
-    const expectedData = [{
-      ...mockEnterpriseList.results[0],
-      link: (<Link replace={false} to="/enterprise-1/admin">Enterprise 1</Link>),
-    }, {
-      ...mockEnterpriseList.results[1],
-      link: (<Link replace={false} to="/enterprise-2/admin">Enterprise 2</Link>),
-    }];
+    const expectedData = mockEnterpriseList.results;
 
     beforeEach(() => {
       wrapper = shallow((

--- a/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
+++ b/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
@@ -11,12 +11,9 @@ exports[`<EnterpriseList /> renders correctly calls getEnterpriseList, clearPort
       <div
         className="col"
       >
-        <h2>
+        <h1>
           Enterprise List
-        </h2>
-        <div
-          className="py-3"
-        />
+        </h1>
       </div>
     </div>
   </div>
@@ -34,41 +31,37 @@ exports[`<EnterpriseList /> renders correctly with empty enrollment data 1`] = `
       <div
         className="col"
       >
-        <h2>
+        <h1>
           Enterprise List
-        </h2>
+        </h1>
         <div
-          className="py-3"
+          className="alert fade alert-warning show"
+          hidden={false}
+          role="alert"
         >
           <div
-            className="alert fade alert-warning show"
-            hidden={false}
-            role="alert"
+            className="alert-dialog"
           >
             <div
-              className="alert-dialog"
+              className="d-flex"
             >
               <div
-                className="d-flex"
+                className="icon mr-2"
               >
-                <div
-                  className="icon mr-2"
-                >
-                  <div>
-                    <span
-                      aria-hidden={true}
-                      className="fa fa-exclamation-circle"
-                      id="Icon1"
-                    />
-                  </div>
+                <div>
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-exclamation-circle"
+                    id="Icon1"
+                  />
                 </div>
-                <div
-                  className="message"
-                >
-                  <span>
-                    You do not have permission to view any enterprise customer data.
-                  </span>
-                </div>
+              </div>
+              <div
+                className="message"
+              >
+                <span>
+                  You do not have permission to view any enterprise customer data.
+                </span>
               </div>
             </div>
           </div>
@@ -90,403 +83,399 @@ exports[`<EnterpriseList /> renders correctly with enrollment data 1`] = `
       <div
         className="col"
       >
-        <h2>
+        <h1>
           Enterprise List
-        </h2>
+        </h1>
         <div
-          className="py-3"
+          className={null}
         >
           <div
-            className={null}
+            className="row"
           >
             <div
-              className="row"
+              className="col"
             >
               <div
-                className="col"
+                className="table-responsive"
               >
-                <div
-                  className="table-responsive"
+                <table
+                  className="table table-sm table-striped"
                 >
-                  <table
-                    className="table table-sm table-striped"
+                  <thead
+                    className=""
                   >
-                    <thead
+                    <tr
                       className=""
                     >
-                      <tr
+                      <th
                         className=""
+                        scope="col"
                       >
-                        <th
-                          className=""
-                          scope="col"
-                        >
-                          Enterprise
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody
+                        Enterprise
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    className=""
+                  >
+                    <tr
                       className=""
                     >
-                      <tr
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-1/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-1/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 1
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 1
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-2/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-2/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 2
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 2
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-3/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-3/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 3
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 3
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-4/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-4/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 4
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 4
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-5/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-5/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 5
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 5
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-6/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-6/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 6
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 6
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-7/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-7/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 7
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 7
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-8/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-8/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 8
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 8
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-9/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-9/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 9
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 9
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-10/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-10/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 10
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 10
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-11/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-11/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 11
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 11
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-12/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-12/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 12
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 12
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-13/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-13/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 13
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 13
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-14/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-14/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 14
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 14
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-15/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-15/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 15
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 15
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-16/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-16/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 16
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 16
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-17/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-17/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 17
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 17
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-18/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-18/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 18
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 18
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-19/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-19/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 19
-                          </a>
-                        </td>
-                      </tr>
-                      <tr
+                          Enterprise 19
+                        </a>
+                      </td>
+                    </tr>
+                    <tr
+                      className=""
+                    >
+                      <td
                         className=""
                       >
-                        <td
-                          className=""
+                        <a
+                          href="/enterprise-20/admin"
+                          onClick={[Function]}
                         >
-                          <a
-                            href="/enterprise-20/admin"
-                            onClick={[Function]}
-                          >
-                            Enterprise 20
-                          </a>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
+                          Enterprise 20
+                        </a>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
+          </div>
+          <div
+            className="row mt-2"
+          >
             <div
-              className="row mt-2"
+              className="col d-flex justify-content-center"
             >
-              <div
-                className="col d-flex justify-content-center"
+              <nav
+                aria-label="enterprise list pagination"
+                className=""
               >
-                <nav
-                  aria-label="enterprise list pagination"
-                  className=""
+                <div
+                  aria-atomic={true}
+                  aria-live="polite"
+                  aria-relevant="text"
+                  className="sr-only"
                 >
-                  <div
-                    aria-atomic={true}
-                    aria-live="polite"
-                    aria-relevant="text"
-                    className="sr-only"
+                  Page 1, Current Page, of 2
+                </div>
+                <ul
+                  className="pagination"
+                >
+                  <li
+                    className="page-item disabled"
                   >
-                    Page 1, Current Page, of 2
-                  </div>
-                  <ul
-                    className="pagination"
+                    <button
+                      aria-label="Previous"
+                      className="btn previous page-link"
+                      disabled={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex="-1"
+                      type="button"
+                    >
+                      <div>
+                        <div>
+                          <span
+                            aria-hidden={true}
+                            className="fa fa-chevron-left mr-2"
+                            id="pagination-2"
+                          />
+                        </div>
+                        Previous
+                      </div>
+                    </button>
+                  </li>
+                  <li
+                    className="page-item"
                   >
-                    <li
-                      className="page-item disabled"
+                    <button
+                      aria-label="Next, Page 2"
+                      className="btn next page-link"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex={undefined}
+                      type="button"
                     >
-                      <button
-                        aria-label="Previous"
-                        className="btn previous page-link"
-                        disabled={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        tabIndex="-1"
-                        type="button"
-                      >
+                      <div>
+                        Next
                         <div>
-                          <div>
-                            <span
-                              aria-hidden={true}
-                              className="fa fa-chevron-left mr-2"
-                              id="pagination-2"
-                            />
-                          </div>
-                          Previous
+                          <span
+                            aria-hidden={true}
+                            className="fa fa-chevron-right ml-2"
+                            id="pagination-3"
+                          />
                         </div>
-                      </button>
-                    </li>
-                    <li
-                      className="page-item"
-                    >
-                      <button
-                        aria-label="Next, Page 2"
-                        className="btn next page-link"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        tabIndex={undefined}
-                        type="button"
-                      >
-                        <div>
-                          Next
-                          <div>
-                            <span
-                              aria-hidden={true}
-                              className="fa fa-chevron-right ml-2"
-                              id="pagination-3"
-                            />
-                          </div>
-                        </div>
-                      </button>
-                    </li>
-                  </ul>
-                </nav>
-              </div>
+                      </div>
+                    </button>
+                  </li>
+                </ul>
+              </nav>
             </div>
           </div>
         </div>
@@ -507,46 +496,42 @@ exports[`<EnterpriseList /> renders correctly with error state 1`] = `
       <div
         className="col"
       >
-        <h2>
+        <h1>
           Enterprise List
-        </h2>
+        </h1>
         <div
-          className="py-3"
+          className="alert fade alert-danger show"
+          hidden={false}
+          role="alert"
         >
           <div
-            className="alert fade alert-danger show"
-            hidden={false}
-            role="alert"
+            className="alert-dialog"
           >
             <div
-              className="alert-dialog"
+              className="d-flex"
             >
               <div
-                className="d-flex"
+                className="icon mr-2"
               >
-                <div
-                  className="icon mr-2"
-                >
-                  <div>
-                    <span
-                      aria-hidden={true}
-                      className="fa fa-times-circle"
-                      id="Icon1"
-                    />
-                  </div>
-                </div>
-                <div
-                  className="message"
-                >
+                <div>
                   <span
-                    className="title"
-                  >
-                    Unable to load enterprise list
-                  </span>
-                  <span>
-                    Try refreshing your screen (Network Error)
-                  </span>
+                    aria-hidden={true}
+                    className="fa fa-times-circle"
+                    id="Icon1"
+                  />
                 </div>
+              </div>
+              <div
+                className="message"
+              >
+                <span
+                  className="title"
+                >
+                  Unable to load enterprise list
+                </span>
+                <span>
+                  Try refreshing your screen (Network Error)
+                </span>
               </div>
             </div>
           </div>
@@ -568,19 +553,15 @@ exports[`<EnterpriseList /> renders correctly with loading state 1`] = `
       <div
         className="col"
       >
-        <h2>
+        <h1>
           Enterprise List
-        </h2>
+        </h1>
         <div
-          className="py-3"
+          className="enterprise-list loading d-flex align-items-center justify-content-center"
         >
-          <div
-            className="enterprise-list loading d-flex align-items-center justify-content-center"
-          >
-            <span>
-              Loading...
-            </span>
-          </div>
+          <span>
+            Loading...
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/EnterpriseList/index.jsx
+++ b/src/components/EnterpriseList/index.jsx
@@ -4,7 +4,7 @@ import { Link, Redirect } from 'react-router-dom';
 import Helmet from 'react-helmet';
 import qs from 'query-string';
 
-import H2 from '../H2';
+import H1 from '../H1';
 import StatusAlert from '../StatusAlert';
 import LoadingMessage from '../LoadingMessage';
 import TableWithPagination from '../TableWithPagination';
@@ -23,11 +23,11 @@ class EnterpriseList extends React.Component {
           key: 'link',
         },
       ],
-      enterprises: this.formatEnterpriseData(enterprises),
-      pageCount: enterprises ? enterprises.num_pages : null,
+      enterprises: enterprises && enterprises.results,
+      pageCount: enterprises && enterprises.num_pages,
     };
 
-    this.renderTableContent = this.renderTableContent.bind(this);
+    this.formatEnterpriseData = this.formatEnterpriseData.bind(this);
   }
 
   componentDidMount() {
@@ -42,8 +42,8 @@ class EnterpriseList extends React.Component {
 
     if (enterprises !== prevProps.enterprises) {
       this.setState({ // eslint-disable-line react/no-did-update-set-state
-        enterprises: this.formatEnterpriseData(enterprises),
-        pageCount: enterprises ? enterprises.num_pages : null,
+        enterprises: enterprises && enterprises.results,
+        pageCount: enterprises && enterprises.num_pages,
       });
     }
   }
@@ -59,12 +59,12 @@ class EnterpriseList extends React.Component {
   formatEnterpriseData(enterprises) {
     if (!enterprises) {
       return null;
-    } else if (!enterprises.results.length) {
+    } else if (!enterprises.length) {
       return [];
     }
 
-    return enterprises.results.map(enterprise => ({
-      link: (<Link to={`/${enterprise.slug}/admin`}>{enterprise.name}</Link>),
+    return enterprises.map(enterprise => ({
+      link: <Link to={`/${enterprise.slug}/admin`}>{enterprise.name}</Link>,
       name: enterprise.name,
       slug: enterprise.slug,
       uuid: enterprise.uuid,
@@ -115,6 +115,7 @@ class EnterpriseList extends React.Component {
         handleDataUpdate={options =>
           this.getEnterpriseList(options)
         }
+        formatData={this.formatEnterpriseData}
       />
     );
   }
@@ -135,18 +136,16 @@ class EnterpriseList extends React.Component {
         <div className="container">
           <div className="row mt-4">
             <div className="col">
-              <H2>Enterprise List</H2>
-              <div className="py-3">
-                {error && this.renderErrorMessage()}
-                {loading && !enterprises && this.renderLoadingMessage()}
-                {!loading && !error && enterprises && enterprises.length === 0 &&
-                  this.renderEmptyEnterpriseListMessage()
-                }
-                {!loading && !error && enterprises && enterprises.length === 1 && pageCount === 1 &&
-                  this.renderRedirectToEnterpriseAdminPage()
-                }
-                {enterprises && enterprises.length > 0 && this.renderTableContent()}
-              </div>
+              <H1>Enterprise List</H1>
+              {error && this.renderErrorMessage()}
+              {loading && !enterprises && this.renderLoadingMessage()}
+              {!loading && !error && enterprises && enterprises.length === 0 &&
+                this.renderEmptyEnterpriseListMessage()
+              }
+              {!loading && !error && enterprises && enterprises.length === 1 && pageCount === 1 &&
+                this.renderRedirectToEnterpriseAdminPage()
+              }
+              {enterprises && enterprises.length > 0 && this.renderTableContent()}
             </div>
           </div>
         </div>

--- a/src/components/TableWithPagination/TableWithPagination.test.jsx
+++ b/src/components/TableWithPagination/TableWithPagination.test.jsx
@@ -13,6 +13,7 @@ const TableWithPaginationWrapper = props => (
       pageCount={props.pageCount}
       data={[]}
       paginationLabel="pagination"
+      formatData={data => data}
       {...props}
     />
   </MemoryRouter>


### PR DESCRIPTION
Adds client-side sorting to `TableWithPagination` to avoid making unnecessary API calls when there's only 1 page of table data.

Note that the sorting function being in `TableWithPagination` means it should be able to sort any type of data (e.g., strings, dates, numbers). The [`sortTableData` function](https://github.com/edx/edx-portal/compare/astankiewicz/client-table-sorting?expand=1#diff-499b0c7921fe2ca35e04265122d9da23R83) uses lodash's `orderBy` to simplify the sorting logic.