### PR TITLE
Remove new relic env vars from dev build

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -103,8 +103,6 @@ module.exports = Merge.smart(commonConfig, {
       DATA_API_BASE_URL: 'http://localhost:8000',
       LMS_CLIENT_ID: 'CMehRRNqfiBRVJKnPOkjBDjAvurtnHpELoehKAvZ',
       SEGMENT_KEY: '',
-      NEW_RELIC_APP_ID: undefined,
-      NEW_RELIC_LICENSE_KEY: undefined,
     }),
   ],
   // This configures webpack-dev-server which serves bundles from memory and provides live

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,6 +4,4 @@ export default {
   LMS_CLIENT_ID: process.env.LMS_CLIENT_ID,
   SECURE_COOKIES: process.env.NODE_ENV !== 'development',
   SEGMENT_KEY: process.env.SEGMENT_KEY,
-  NEW_RELIC_APP_ID: process.env.NEW_RELIC_APP_ID,
-  NEW_RELIC_LICENSE_KEY: process.env.NEW_RELIC_LICENSE_KEY,
 };


### PR DESCRIPTION
We are getting warnings about the New Relic keys being `undefined` when building in the dev environment:

![image](https://user-images.githubusercontent.com/2828721/44361379-ac202f80-a48b-11e8-8f09-8af3592719f7.png)

Since only the prod webpack config uses the New Relic plugin, we can safely remove the env vars from the dev webpack config as well as `src/config/index.js`.