### PR TITLE
Removes demoDataLoader from chunking in our prod bundles

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -111,7 +111,10 @@ module.exports = Merge.smart(commonConfig, {
           enforce: true,
         },
       },
-      chunks: 'all',
+      chunks(chunk) {
+        // Exclude demoDataLoader from chunking
+        return chunk.name !== 'demoDataLoader';
+      },
     },
   },
   // Specify additional processing or side-effects done on the Webpack output bundles as a whole.


### PR DESCRIPTION
While we were excluding the demoDataLoader.js file from our production bundle, it
was still being chunked so the the vendors~demoDataLoader.js chunk was being included
in the body and included faker.js which is unnecessary outside the demoDataLoader

This change now removes that chunking