### PR TITLE
Learner activity details

### DIFF
--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -14,6 +14,8 @@ import RegisteredLearnersTable from '../RegisteredLearnersTable';
 import EnrolledLearnersTable from '../EnrolledLearnersTable';
 import CompletedLearnersTable from '../CompletedLearnersTable';
 import PastWeekPassedLearnersTable from '../PastWeekPassedLearnersTable';
+import LearnerActivityTable from '../LearnerActivityTable';
+
 import AdminCards from '../../containers/AdminCards';
 
 import { formatTimestamp } from '../../utils';
@@ -60,17 +62,17 @@ class Admin extends React.Component {
       active: {
         title: 'Learners Enrolled in a Course',
         subtitle: 'Top Active Learners',
-        component: <EnrollmentsTable />,
+        component: <LearnerActivityTable id="active-week" activity="active_past_week" />,
       },
       'inactive-week': {
         title: 'Learners Enrolled in a Course',
         subtitle: 'Not Active in Past Week',
-        component: <EnrollmentsTable />,
+        component: <LearnerActivityTable id="inactive-week" activity="inactive_past_week" />,
       },
       'inactive-month': {
         title: 'Learners Enrolled in a Course',
         subtitle: 'Not Active in Past Month',
-        component: <EnrollmentsTable />,
+        component: <LearnerActivityTable id="inactive-month" activity="inactive_past_month" />,
       },
       completed: {
         title: 'Number of Courses Completed by Learner',

--- a/src/components/CompletedLearnersTable/index.jsx
+++ b/src/components/CompletedLearnersTable/index.jsx
@@ -8,10 +8,12 @@ const CompletedLearnersTable = () => {
     {
       label: 'Email',
       key: 'user_email',
+      columnSortable: true,
     },
     {
       label: 'Total Course Completed Count',
       key: 'completed_courses',
+      columnSortable: true,
     },
   ];
 

--- a/src/components/LearnerActivityTable/LearnerActivityTable.test.jsx
+++ b/src/components/LearnerActivityTable/LearnerActivityTable.test.jsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import { mount } from 'enzyme';
+
+import LearnerActivityTable from '.';
+
+const mockStore = configureMockStore([thunk]);
+const learnerActivityEmptyStore = mockStore({
+  table: {
+    'active-week': {
+      data: {
+        results: [],
+        current_page: 1,
+        num_pages: 1,
+      },
+      ordering: null,
+      loading: false,
+      error: null,
+    },
+  },
+});
+
+const tableMockData = {
+  data: {
+    count: 2,
+    num_pages: 1,
+    current_page: 1,
+    results: [
+      {
+        id: 1,
+        passed_timestamp: '2018-09-23T16:27:34.690065Z',
+        course_title: 'Dive into ReactJS',
+        course_key: 'edX/ReactJS',
+        user_email: 'awesome.me@example.com',
+        course_price: '200',
+        course_start: '2017-10-21T23:47:32.738Z',
+        course_end: '2018-05-13T12:47:27.534Z',
+        current_grade: '0.66',
+        last_activity_date: '2018-09-22T10:59:28.628Z',
+      },
+      {
+        id: 5,
+        passed_timestamp: '2018-09-22T16:27:34.690065Z',
+        course_title: 'Redux with ReactJS',
+        course_key: 'edX/Redux_ReactJS',
+        user_email: 'new@example.com',
+        course_price: '200',
+        course_start: '2017-10-21T23:47:32.738Z',
+        course_end: '2018-05-13T12:47:27.534Z',
+        current_grade: '0.80',
+        last_activity_date: '2018-09-25T10:59:28.628Z',
+      },
+    ],
+    next: null,
+    start: 0,
+    previous: null,
+  },
+  ordering: null,
+  loading: false,
+  error: null,
+};
+
+const learnerActivityStore = mockStore({
+  table: {
+    'active-week': tableMockData,
+    'inactive-week': tableMockData,
+    'inactive-month': tableMockData,
+  },
+});
+
+const LearnerActivityEmptyTableWrapper = props => (
+  <Provider store={learnerActivityEmptyStore}>
+    <LearnerActivityTable
+      {...props}
+    />
+  </Provider>
+);
+
+const LearnerActivityTableWrapper = props => (
+  <Provider store={learnerActivityStore}>
+    <LearnerActivityTable
+      {...props}
+    />
+  </Provider>
+);
+
+const verifyLearnerActivityTableRendered = (tableId, activity, columnTitles, rowsData) => {
+  const wrapper = mount((
+    <LearnerActivityTableWrapper id={tableId} activity={activity} />
+  ));
+  // Verify that table has correct number of columns
+  expect(wrapper.find(`.${tableId} thead th`).length).toEqual(columnTitles.length);
+
+  // Verify only expected columns are shown
+  wrapper.find(`.${tableId} thead th`).forEach((column, index) => {
+    expect(column.text()).toContain(columnTitles[index]);
+  });
+
+  // Verify that table has correct number of rows
+  expect(wrapper.find(`.${tableId} tbody tr`).length).toEqual(2);
+
+  // Verify each row in table has correct data
+  wrapper.find(`.${tableId} tbody tr`).forEach((row, rowIndex) => {
+    row.find('td').forEach((cell, colIndex) => {
+      expect(cell.text()).toEqual(rowsData[rowIndex][colIndex]);
+    });
+  });
+};
+
+describe('LearnerActivityTable', () => {
+  it('renders empty state correctly', () => {
+    const tree = renderer
+      .create((
+        <LearnerActivityEmptyTableWrapper id="active-week" activity="active_past_week" />
+      ))
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders active learners table correctly', () => {
+    const tree = renderer
+      .create((
+        <LearnerActivityTableWrapper id="active-week" activity="active_past_week" />
+      ))
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders inactive past week learners table correctly', () => {
+    const tree = renderer
+      .create((
+        <LearnerActivityTableWrapper id="inactive-week" activity="inactive_past_week" />
+      ))
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders inactive past month learners table correctly', () => {
+    const tree = renderer
+      .create((
+        <LearnerActivityTableWrapper id="inactive-month" activity="inactive_past_month" />
+      ))
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders active learners table with correct data', () => {
+    const tableId = 'active-week';
+    const activity = 'active_past_week';
+    const columnTitles = [
+      'Email',
+      'Course Title',
+      'Course Price',
+      'Start Date',
+      'End Date',
+      'Passed Date',
+      'Current Grade',
+      'Last Activity Date',
+    ];
+    const rowsData = [
+      [
+        'awesome.me@example.com',
+        'Dive into ReactJS',
+        '$200',
+        'October 21, 2017',
+        'May 13, 2018',
+        'September 23, 2018',
+        '66%',
+        'September 22, 2018',
+      ],
+      [
+        'new@example.com',
+        'Redux with ReactJS',
+        '$200',
+        'October 21, 2017',
+        'May 13, 2018',
+        'September 22, 2018',
+        '80%',
+        'September 25, 2018',
+      ],
+    ];
+
+    verifyLearnerActivityTableRendered(tableId, activity, columnTitles, rowsData);
+  });
+
+  it('renders inactive past week learners table with correct data', () => {
+    const tableId = 'inactive-week';
+    const activity = 'inactive_past_week';
+    const columnTitles = [
+      'Email',
+      'Course Title',
+      'Course Price',
+      'Start Date',
+      'End Date',
+      'Current Grade',
+      'Last Activity Date',
+    ];
+    const rowsData = [
+      [
+        'awesome.me@example.com',
+        'Dive into ReactJS',
+        '$200',
+        'October 21, 2017',
+        'May 13, 2018',
+        '66%',
+        'September 22, 2018',
+      ],
+      [
+        'new@example.com',
+        'Redux with ReactJS',
+        '$200',
+        'October 21, 2017',
+        'May 13, 2018',
+        '80%',
+        'September 25, 2018',
+      ],
+    ];
+
+    verifyLearnerActivityTableRendered(tableId, activity, columnTitles, rowsData);
+  });
+
+  it('renders inactive past month learners table with correct data', () => {
+    const tableId = 'inactive-month';
+    const activity = 'inactive_past_month';
+    const columnTitles = [
+      'Email',
+      'Course Title',
+      'Course Price',
+      'Start Date',
+      'End Date',
+      'Current Grade',
+      'Last Activity Date',
+    ];
+    const rowsData = [
+      [
+        'awesome.me@example.com',
+        'Dive into ReactJS',
+        '$200',
+        'October 21, 2017',
+        'May 13, 2018',
+        '66%',
+        'September 22, 2018',
+      ],
+      [
+        'new@example.com',
+        'Redux with ReactJS',
+        '$200',
+        'October 21, 2017',
+        'May 13, 2018',
+        '80%',
+        'September 25, 2018',
+      ],
+    ];
+
+    verifyLearnerActivityTableRendered(tableId, activity, columnTitles, rowsData);
+  });
+});

--- a/src/components/LearnerActivityTable/__snapshots__/LearnerActivityTable.test.jsx.snap
+++ b/src/components/LearnerActivityTable/__snapshots__/LearnerActivityTable.test.jsx.snap
@@ -1,0 +1,1212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LearnerActivityTable renders active learners table correctly 1`] = `
+<div>
+  <div
+    className="active-week"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <div
+          className="table-responsive"
+        >
+          <table
+            className="table table-sm table-striped"
+          >
+            <thead
+              className=""
+            >
+              <tr
+                className=""
+              >
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Email
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        sort ascending
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort-asc"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Course Title
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Course Price
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Start Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      End Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Passed Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Current Grade
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Last Activity Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              className=""
+            >
+              <tr
+                className=""
+              >
+                <td
+                  className=""
+                >
+                  awesome.me@example.com
+                </td>
+                <td
+                  className=""
+                >
+                  Dive into ReactJS
+                </td>
+                <td
+                  className=""
+                >
+                  $200
+                </td>
+                <td
+                  className=""
+                >
+                  October 21, 2017
+                </td>
+                <td
+                  className=""
+                >
+                  May 13, 2018
+                </td>
+                <td
+                  className=""
+                >
+                  September 23, 2018
+                </td>
+                <td
+                  className=""
+                >
+                  66%
+                </td>
+                <td
+                  className=""
+                >
+                  September 22, 2018
+                </td>
+              </tr>
+              <tr
+                className=""
+              >
+                <td
+                  className=""
+                >
+                  new@example.com
+                </td>
+                <td
+                  className=""
+                >
+                  Redux with ReactJS
+                </td>
+                <td
+                  className=""
+                >
+                  $200
+                </td>
+                <td
+                  className=""
+                >
+                  October 21, 2017
+                </td>
+                <td
+                  className=""
+                >
+                  May 13, 2018
+                </td>
+                <td
+                  className=""
+                >
+                  September 22, 2018
+                </td>
+                <td
+                  className=""
+                >
+                  80%
+                </td>
+                <td
+                  className=""
+                >
+                  September 25, 2018
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row mt-2"
+    >
+      <div
+        className="col d-flex justify-content-center"
+      >
+        <nav
+          aria-label="active-week-pagination"
+          className=""
+        >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
+          >
+            Page 1, Current Page, of 1
+          </div>
+          <ul
+            className="pagination"
+          >
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Previous"
+                className="btn previous page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  <span>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-left mr-2"
+                      id="pagination-2"
+                    />
+                  </span>
+                  Previous
+                </div>
+              </button>
+            </li>
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Next"
+                className="btn next page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  Next
+                  <span>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-right ml-2"
+                      id="pagination-3"
+                    />
+                  </span>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LearnerActivityTable renders empty state correctly 1`] = `
+<div>
+  <div
+    className="alert fade alert-warning show"
+    hidden={false}
+    role="alert"
+  >
+    <div
+      className="alert-dialog"
+    >
+      <div
+        className="d-flex"
+      >
+        <div
+          className="icon mr-2"
+        >
+          <span>
+            <span
+              aria-hidden={true}
+              className="fa fa-exclamation-circle"
+              id="Icon1"
+            />
+          </span>
+        </div>
+        <div
+          className="message"
+        >
+          <span>
+            There are no results.
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LearnerActivityTable renders inactive past month learners table correctly 1`] = `
+<div>
+  <div
+    className="inactive-month"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <div
+          className="table-responsive"
+        >
+          <table
+            className="table table-sm table-striped"
+          >
+            <thead
+              className=""
+            >
+              <tr
+                className=""
+              >
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Email
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        sort ascending
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort-asc"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Course Title
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Course Price
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Start Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      End Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Current Grade
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Last Activity Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              className=""
+            >
+              <tr
+                className=""
+              >
+                <td
+                  className=""
+                >
+                  awesome.me@example.com
+                </td>
+                <td
+                  className=""
+                >
+                  Dive into ReactJS
+                </td>
+                <td
+                  className=""
+                >
+                  $200
+                </td>
+                <td
+                  className=""
+                >
+                  October 21, 2017
+                </td>
+                <td
+                  className=""
+                >
+                  May 13, 2018
+                </td>
+                <td
+                  className=""
+                >
+                  66%
+                </td>
+                <td
+                  className=""
+                >
+                  September 22, 2018
+                </td>
+              </tr>
+              <tr
+                className=""
+              >
+                <td
+                  className=""
+                >
+                  new@example.com
+                </td>
+                <td
+                  className=""
+                >
+                  Redux with ReactJS
+                </td>
+                <td
+                  className=""
+                >
+                  $200
+                </td>
+                <td
+                  className=""
+                >
+                  October 21, 2017
+                </td>
+                <td
+                  className=""
+                >
+                  May 13, 2018
+                </td>
+                <td
+                  className=""
+                >
+                  80%
+                </td>
+                <td
+                  className=""
+                >
+                  September 25, 2018
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row mt-2"
+    >
+      <div
+        className="col d-flex justify-content-center"
+      >
+        <nav
+          aria-label="inactive-month-pagination"
+          className=""
+        >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
+          >
+            Page 1, Current Page, of 1
+          </div>
+          <ul
+            className="pagination"
+          >
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Previous"
+                className="btn previous page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  <span>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-left mr-2"
+                      id="pagination-6"
+                    />
+                  </span>
+                  Previous
+                </div>
+              </button>
+            </li>
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Next"
+                className="btn next page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  Next
+                  <span>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-right ml-2"
+                      id="pagination-7"
+                    />
+                  </span>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LearnerActivityTable renders inactive past week learners table correctly 1`] = `
+<div>
+  <div
+    className="inactive-week"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <div
+          className="table-responsive"
+        >
+          <table
+            className="table table-sm table-striped"
+          >
+            <thead
+              className=""
+            >
+              <tr
+                className=""
+              >
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Email
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        sort ascending
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort-asc"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Course Title
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Course Price
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Start Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      End Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Current Grade
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+                <th
+                  className="sortable"
+                  scope="col"
+                >
+                  <button
+                    className="btn btn-header"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Last Activity Date
+                      <span
+                        className="sr-only"
+                      >
+                         
+                        click to sort
+                      </span>
+                       
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-sort"
+                      />
+                    </span>
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              className=""
+            >
+              <tr
+                className=""
+              >
+                <td
+                  className=""
+                >
+                  awesome.me@example.com
+                </td>
+                <td
+                  className=""
+                >
+                  Dive into ReactJS
+                </td>
+                <td
+                  className=""
+                >
+                  $200
+                </td>
+                <td
+                  className=""
+                >
+                  October 21, 2017
+                </td>
+                <td
+                  className=""
+                >
+                  May 13, 2018
+                </td>
+                <td
+                  className=""
+                >
+                  66%
+                </td>
+                <td
+                  className=""
+                >
+                  September 22, 2018
+                </td>
+              </tr>
+              <tr
+                className=""
+              >
+                <td
+                  className=""
+                >
+                  new@example.com
+                </td>
+                <td
+                  className=""
+                >
+                  Redux with ReactJS
+                </td>
+                <td
+                  className=""
+                >
+                  $200
+                </td>
+                <td
+                  className=""
+                >
+                  October 21, 2017
+                </td>
+                <td
+                  className=""
+                >
+                  May 13, 2018
+                </td>
+                <td
+                  className=""
+                >
+                  80%
+                </td>
+                <td
+                  className=""
+                >
+                  September 25, 2018
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row mt-2"
+    >
+      <div
+        className="col d-flex justify-content-center"
+      >
+        <nav
+          aria-label="inactive-week-pagination"
+          className=""
+        >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
+          >
+            Page 1, Current Page, of 1
+          </div>
+          <ul
+            className="pagination"
+          >
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Previous"
+                className="btn previous page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  <span>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-left mr-2"
+                      id="pagination-4"
+                    />
+                  </span>
+                  Previous
+                </div>
+              </button>
+            </li>
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Next"
+                className="btn next page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  Next
+                  <span>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-right ml-2"
+                      id="pagination-5"
+                    />
+                  </span>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/LearnerActivityTable/index.jsx
+++ b/src/components/LearnerActivityTable/index.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import TableContainer from '../../containers/TableContainer';
 import { formatTimestamp, formatPassedTimestamp, formatPercentage } from '../../utils';
 import EnterpriseDataApiService from '../../data/services/EnterpriseDataApiService';
 
-const EnrollmentsTable = () => {
-  const enrollmentTableColumns = [
+const LearnerActivityTable = (props) => {
+  const { activity, id } = props;
+  const tableColumns = [
     {
       label: 'Email',
       key: 'user_email',
@@ -48,7 +50,14 @@ const EnrollmentsTable = () => {
     },
   ];
 
-  const formatEnrollmentData = enrollments => enrollments.map(enrollment => ({
+  const getTableColumns = () => {
+    if (activity !== 'active_past_week') {
+      return tableColumns.filter(column => column.key !== 'passed_timestamp');
+    }
+    return tableColumns;
+  };
+
+  const formatTableData = enrollments => enrollments.map(enrollment => ({
     ...enrollment,
     last_activity_date: formatTimestamp({ timestamp: enrollment.last_activity_date }),
     course_start: formatTimestamp({ timestamp: enrollment.course_start }),
@@ -67,14 +76,21 @@ const EnrollmentsTable = () => {
 
   return (
     <TableContainer
-      id="enrollments"
-      className="enrollments"
-      fetchMethod={EnterpriseDataApiService.fetchCourseEnrollments}
-      columns={enrollmentTableColumns}
-      formatData={formatEnrollmentData}
+      id={id}
+      className={id}
+      fetchMethod={() => EnterpriseDataApiService.fetchCourseEnrollments({
+        learner_activity: activity,
+      })}
+      columns={getTableColumns()}
+      formatData={formatTableData}
       tableSortable
     />
   );
 };
 
-export default EnrollmentsTable;
+LearnerActivityTable.propTypes = {
+  id: PropTypes.string.isRequired,
+  activity: PropTypes.string.isRequired,
+};
+
+export default LearnerActivityTable;

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -15,6 +15,13 @@ class TableComponent extends React.Component {
     this.props.paginateTable();
   }
 
+  componentDidUpdate(prevProps) {
+    const { id } = this.props;
+    if (id && id !== prevProps.id) {
+      this.props.paginateTable();
+    }
+  }
+
   componentWillUnmount() {
     this.props.clearTable();
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,13 @@ const formatTimestamp = ({ timestamp, format = 'MMMM D, YYYY' }) => {
   return null;
 };
 
+const formatPassedTimestamp = (timestamp) => {
+  if (timestamp) {
+    return formatTimestamp({ timestamp });
+  }
+  return 'Has not passed';
+};
+
 const formatPercentage = ({ decimal, numDecimals = 1 }) => (
   decimal ? `${parseFloat((decimal * 100).toFixed(numDecimals))}%` : ''
 );
@@ -34,6 +41,7 @@ const removeTrailingSlash = path => path.replace(/\/$/, '');
 
 export {
   formatPercentage,
+  formatPassedTimestamp,
   formatTimestamp,
   getAccessToken,
   removeTrailingSlash,


### PR DESCRIPTION
This PR adds front-end functionality for Learner Activity cards. They include:
1. Active learners in past week.
2. Inactive learners in past week.
3. Inactive learners in past month.

Related enterprise-data PR: https://github.com/edx/edx-enterprise-data/pull/64

[ENT-1166](https://openedx.atlassian.net/browse/ENT-1166)
[ENT-1218](https://openedx.atlassian.net/browse/ENT-1218)

