### PR TITLE
Support temporarily enabling feature flags with query parameter

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,3 +1,10 @@
+import qs from 'query-string';
+
+const hasFeatureFlagEnabled = (featureFlag) => {
+  const { features } = qs.parse(window.location.search);
+  return features && features.split(',').includes(featureFlag);
+};
+
 const configuration = {
   LMS_BASE_URL: process.env.LMS_BASE_URL,
   DATA_API_BASE_URL: process.env.DATA_API_BASE_URL,
@@ -7,7 +14,7 @@ const configuration = {
 };
 
 const features = {
-  DASHBOARD_V2: process.env.FEATURE_FLAGS.DASHBOARD_V2,
+  DASHBOARD_V2: process.env.FEATURE_FLAGS.DASHBOARD_V2 || hasFeatureFlagEnabled('DASHBOARD_V2'),
 };
 
 export { configuration, features };

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,12 +29,13 @@ const updateUrl = (data) => {
     })}`);
   }
 };
+
 const removeTrailingSlash = path => path.replace(/\/$/, '');
 
 export {
-  formatTimestamp,
   formatPercentage,
+  formatTimestamp,
   getAccessToken,
-  updateUrl,
   removeTrailingSlash,
+  updateUrl,
 };


### PR DESCRIPTION
If some features are behind a feature flag (e.g., the collapsible cards), it's impossible to see and verify changes on stage and prod. This PR supports temporarily enabling one or more feature flags by passing a `features` URL query parameter. To have more than one feature enabled, simply put them in a comma-separated list:

```
http://localhost:1991/enterprise-slug/admin/learners?features=DASHBOARD_V2

http://localhost:1991/enterprise-slug/admin/learners?features=DASHBOARD_V2,OTHER_FEATURE
```