### PR TITLE
Ensure all card action tables have a CSV fetch method

### DIFF
--- a/src/components/Admin/Admin.test.jsx
+++ b/src/components/Admin/Admin.test.jsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
+import EnterpriseDataApiService from '../../data/services/EnterpriseDataApiService';
 import Admin from './index';
 
 import { features } from '../../config';
@@ -94,7 +95,7 @@ describe('<Admin />', () => {
               match={{
                 url: '/',
                 params: {
-                  actionSlug: 'registered',
+                  actionSlug: 'registered-unenrolled-learners',
                 },
               }}
             />
@@ -111,7 +112,7 @@ describe('<Admin />', () => {
               match={{
                 url: '/',
                 params: {
-                  actionSlug: 'enrolled',
+                  actionSlug: 'enrolled-learners',
                 },
               }}
             />
@@ -128,7 +129,7 @@ describe('<Admin />', () => {
               match={{
                 url: '/',
                 params: {
-                  actionSlug: 'no-current-courses',
+                  actionSlug: 'enrolled-learners-inactive-courses',
                 },
               }}
             />
@@ -145,7 +146,7 @@ describe('<Admin />', () => {
               match={{
                 url: '/',
                 params: {
-                  actionSlug: 'active',
+                  actionSlug: 'learners-active-week',
                 },
               }}
             />
@@ -162,7 +163,7 @@ describe('<Admin />', () => {
               match={{
                 url: '/',
                 params: {
-                  actionSlug: 'inactive-week',
+                  actionSlug: 'learners-inactive-week',
                 },
               }}
             />
@@ -179,7 +180,7 @@ describe('<Admin />', () => {
               match={{
                 url: '/',
                 params: {
-                  actionSlug: 'inactive-month',
+                  actionSlug: 'learners-inactive-month',
                 },
               }}
             />
@@ -196,7 +197,7 @@ describe('<Admin />', () => {
               match={{
                 url: '/',
                 params: {
-                  actionSlug: 'completed',
+                  actionSlug: 'completed-learners',
                 },
               }}
             />
@@ -213,7 +214,7 @@ describe('<Admin />', () => {
               match={{
                 url: '/',
                 params: {
-                  actionSlug: 'completed-week',
+                  actionSlug: 'completed-learners-week',
                 },
               }}
             />
@@ -292,6 +293,224 @@ describe('<Admin />', () => {
 
       expect(wrapper.prop('enterpriseId')).toEqual(null);
       expect(mockGetDashboardAnalytics).toBeCalled();
+    });
+  });
+
+  describe('calls download csv fetch method for table', () => {
+    let spy;
+
+    afterEach(() => {
+      spy.mockRestore();
+    });
+
+    it('enrollments', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            enrollments: {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('registered unenrolled learners', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchUnenrolledRegisteredLearners');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            'registered-unenrolled-learners': {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+          match={{
+            url: '/',
+            params: {
+              actionSlug: 'registered-unenrolled-learners',
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('enrolled learners', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchEnrolledLearners');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            'enrolled-learners': {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+          match={{
+            url: '/',
+            params: {
+              actionSlug: 'enrolled-learners',
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('enrolled learners inactive courses', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchEnrolledLearnersForInactiveCourses');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            'enrolled-learners-inactive-courses': {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+          match={{
+            url: '/',
+            params: {
+              actionSlug: 'enrolled-learners-inactive-courses',
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('learners active week', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            'learners-active-week': {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+          match={{
+            url: '/',
+            params: {
+              actionSlug: 'learners-active-week',
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('learners inactive week', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            'learners-inactive-week': {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+          match={{
+            url: '/',
+            params: {
+              actionSlug: 'learners-inactive-week',
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('learners inactive month', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            'learners-inactive-month': {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+          match={{
+            url: '/',
+            params: {
+              actionSlug: 'learners-inactive-month',
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('completed learners', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCompletedLearners');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            'completed-learners': {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+          match={{
+            url: '/',
+            params: {
+              actionSlug: 'completed-learners',
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('completed learners past week', () => {
+      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
+      const wrapper = mount((
+        <AdminWrapper
+          enterpriseId="test-enterprise-id"
+          table={{
+            'completed-learners-week': {
+              data: {
+                results: [{ id: 1 }],
+              },
+            },
+          }}
+          match={{
+            url: '/',
+            params: {
+              actionSlug: 'completed-learners-week',
+            },
+          }}
+        />
+      ));
+      wrapper.find('.download-btn').simulate('click');
+      expect(spy).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Admin/Admin.test.jsx
+++ b/src/components/Admin/Admin.test.jsx
@@ -299,218 +299,75 @@ describe('<Admin />', () => {
   describe('calls download csv fetch method for table', () => {
     let spy;
 
+    const actionSlugs = {
+      enrollments: {
+        csvFetchMethod: 'fetchCourseEnrollments',
+        csvFetchParams: [{}, { csv: true }],
+      },
+      'registered-unenrolled-learners': {
+        csvFetchMethod: 'fetchUnenrolledRegisteredLearners',
+        csvFetchParams: [{}, { csv: true }],
+      },
+      'enrolled-learners': {
+        csvFetchMethod: 'fetchEnrolledLearners',
+        csvFetchParams: [{}, { csv: true }],
+      },
+      'enrolled-learners-inactive-courses': {
+        csvFetchMethod: 'fetchEnrolledLearnersForInactiveCourses',
+        csvFetchParams: [{}, { csv: true }],
+      },
+      'learners-active-week': {
+        csvFetchMethod: 'fetchCourseEnrollments',
+        csvFetchParams: [{ learner_activity: 'active_past_week' }, { csv: true }],
+      },
+      'learners-inactive-week': {
+        csvFetchMethod: 'fetchCourseEnrollments',
+        csvFetchParams: [{ learner_activity: 'inactive_past_week' }, { csv: true }],
+      },
+      'learners-inactive-month': {
+        csvFetchMethod: 'fetchCourseEnrollments',
+        csvFetchParams: [{ learner_activity: 'inactive_past_month' }, { csv: true }],
+      },
+      'completed-learners': {
+        csvFetchMethod: 'fetchCompletedLearners',
+        csvFetchParams: [{}, { csv: true }],
+      },
+      'completed-learners-week': {
+        csvFetchMethod: 'fetchCourseEnrollments',
+        csvFetchParams: [{ passed_date: 'last_week' }, { csv: true }],
+      },
+    };
+
     afterEach(() => {
       spy.mockRestore();
     });
 
-    it('enrollments', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            enrollments: {
-              data: {
-                results: [{ id: 1 }],
-              },
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
+    Object.keys(actionSlugs).forEach((key) => {
+      const actionMetadata = actionSlugs[key];
 
-    it('registered unenrolled learners', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchUnenrolledRegisteredLearners');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            'registered-unenrolled-learners': {
-              data: {
-                results: [{ id: 1 }],
+      it(key, () => {
+        spy = jest.spyOn(EnterpriseDataApiService, actionMetadata.csvFetchMethod);
+        const wrapper = mount((
+          <AdminWrapper
+            enterpriseId="test-enterprise-id"
+            table={{
+              [key]: {
+                data: {
+                  results: [{ id: 1 }],
+                },
               },
-            },
-          }}
-          match={{
-            url: '/',
-            params: {
-              actionSlug: 'registered-unenrolled-learners',
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('enrolled learners', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchEnrolledLearners');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            'enrolled-learners': {
-              data: {
-                results: [{ id: 1 }],
+            }}
+            match={{
+              url: '/',
+              params: {
+                actionSlug: key !== 'enrollments' ? key : undefined,
               },
-            },
-          }}
-          match={{
-            url: '/',
-            params: {
-              actionSlug: 'enrolled-learners',
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('enrolled learners inactive courses', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchEnrolledLearnersForInactiveCourses');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            'enrolled-learners-inactive-courses': {
-              data: {
-                results: [{ id: 1 }],
-              },
-            },
-          }}
-          match={{
-            url: '/',
-            params: {
-              actionSlug: 'enrolled-learners-inactive-courses',
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('learners active week', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            'learners-active-week': {
-              data: {
-                results: [{ id: 1 }],
-              },
-            },
-          }}
-          match={{
-            url: '/',
-            params: {
-              actionSlug: 'learners-active-week',
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('learners inactive week', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            'learners-inactive-week': {
-              data: {
-                results: [{ id: 1 }],
-              },
-            },
-          }}
-          match={{
-            url: '/',
-            params: {
-              actionSlug: 'learners-inactive-week',
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('learners inactive month', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            'learners-inactive-month': {
-              data: {
-                results: [{ id: 1 }],
-              },
-            },
-          }}
-          match={{
-            url: '/',
-            params: {
-              actionSlug: 'learners-inactive-month',
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('completed learners', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCompletedLearners');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            'completed-learners': {
-              data: {
-                results: [{ id: 1 }],
-              },
-            },
-          }}
-          match={{
-            url: '/',
-            params: {
-              actionSlug: 'completed-learners',
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('completed learners past week', () => {
-      spy = jest.spyOn(EnterpriseDataApiService, 'fetchCourseEnrollments');
-      const wrapper = mount((
-        <AdminWrapper
-          enterpriseId="test-enterprise-id"
-          table={{
-            'completed-learners-week': {
-              data: {
-                results: [{ id: 1 }],
-              },
-            },
-          }}
-          match={{
-            url: '/',
-            params: {
-              actionSlug: 'completed-learners-week',
-            },
-          }}
-        />
-      ));
-      wrapper.find('.download-btn').simulate('click');
-      expect(spy).toHaveBeenCalled();
+            }}
+          />
+        ));
+        wrapper.find('.download-btn').simulate('click');
+        expect(spy).toHaveBeenCalledWith(...actionMetadata.csvFetchParams);
+      });
     });
   });
 });

--- a/src/components/Admin/AdminCards.jsx
+++ b/src/components/Admin/AdminCards.jsx
@@ -16,7 +16,7 @@ class AdminCards extends React.Component {
         iconClassName: 'fa fa-users',
         actions: [{
           label: 'Which learners are registered but not yet enrolled in any courses?',
-          slug: 'registered',
+          slug: 'registered-unenrolled-learners',
         }],
       },
       enrolledLearners: {
@@ -25,10 +25,10 @@ class AdminCards extends React.Component {
         iconClassName: 'fa fa-check',
         actions: [{
           label: 'How many courses are learners enrolled in?',
-          slug: 'enrolled',
+          slug: 'enrolled-learners',
         }, {
           label: 'Who is no longer enrolled in a current course?',
-          slug: 'no-current-courses',
+          slug: 'enrolled-learners-inactive-courses',
         }],
       },
       activeLearners: {
@@ -37,13 +37,13 @@ class AdminCards extends React.Component {
         iconClassName: 'fa fa-eye',
         actions: [{
           label: 'Who are my top active learners?',
-          slug: 'active',
+          slug: 'learners-active-week',
         }, {
           label: 'Who has not been active for over a week?',
-          slug: 'inactive-week',
+          slug: 'learners-inactive-week',
         }, {
           label: 'Who has not been active for over a month?',
-          slug: 'inactive-month',
+          slug: 'learners-inactive-month',
         }],
       },
       courseCompletions: {
@@ -52,10 +52,10 @@ class AdminCards extends React.Component {
         iconClassName: 'fa fa-trophy',
         actions: [{
           label: 'How many courses have been completed by learners?',
-          slug: 'completed',
+          slug: 'completed-learners',
         }, {
           label: 'Who completed a course in the past week?',
-          slug: 'completed-week',
+          slug: 'completed-learners-week',
         }],
       },
     };

--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -84,7 +84,7 @@ exports[`<Admin /> renders correctly calls getDashboardAnalytics prop 1`] = `
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -105,7 +105,6 @@ exports[`<Admin /> renders correctly calls getDashboardAnalytics prop 1`] = `
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -387,7 +386,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -408,7 +407,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -690,7 +688,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -711,7 +709,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -998,7 +995,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -1019,7 +1016,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -1174,7 +1170,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                 >
                   <a
                     className="btn btn-link"
-                    href="/registered"
+                    href="/registered-unenrolled-learners"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
@@ -1260,7 +1256,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                 >
                   <a
                     className="btn btn-link"
-                    href="/enrolled"
+                    href="/enrolled-learners"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
@@ -1276,7 +1272,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                   </a>
                   <a
                     className="btn btn-link"
-                    href="/no-current-courses"
+                    href="/enrolled-learners-inactive-courses"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
@@ -1362,7 +1358,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                 >
                   <a
                     className="btn btn-link"
-                    href="/active"
+                    href="/learners-active-week"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
@@ -1378,7 +1374,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                   </a>
                   <a
                     className="btn btn-link"
-                    href="/inactive-week"
+                    href="/learners-inactive-week"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
@@ -1394,7 +1390,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                   </a>
                   <a
                     className="btn btn-link"
-                    href="/inactive-month"
+                    href="/learners-inactive-month"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
@@ -1480,7 +1476,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                 >
                   <a
                     className="btn btn-link"
-                    href="/completed"
+                    href="/completed-learners"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
@@ -1496,7 +1492,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                   </a>
                   <a
                     className="btn btn-link"
-                    href="/completed-week"
+                    href="/completed-learners-week"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
@@ -1552,7 +1548,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -1573,7 +1569,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -1838,7 +1833,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -1859,7 +1854,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -2146,7 +2140,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -2167,7 +2161,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -2454,7 +2447,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -2475,7 +2468,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -2760,7 +2752,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -2781,7 +2773,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -3063,7 +3054,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -3084,7 +3075,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -3371,7 +3361,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
           >
             <button
               className="btn btn-outline-primary download-btn"
-              disabled={false}
+              disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -3392,7 +3382,6 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
             </button>
           </div>
         </div>
-        
         <div
           className="mt-3 mb-5"
         >
@@ -3534,7 +3523,6 @@ exports[`<Admin /> renders correctly with error state 1`] = `
       <div
         className="col"
       >
-        
         <div
           className="mt-3 mb-5"
         >
@@ -3646,7 +3634,6 @@ exports[`<Admin /> renders correctly with loading state 1`] = `
       <div
         className="col"
       >
-        
         <div
           className="mt-3 mb-5"
         >

--- a/src/components/DownloadCsvButton/index.jsx
+++ b/src/components/DownloadCsvButton/index.jsx
@@ -13,13 +13,14 @@ class DownloadCsvButton extends React.Component {
       fetchCsv,
       csvLoading,
       match,
+      disabled,
     } = this.props;
     const { params: { slug } } = match;
     const downloadButtonIconClasses = csvLoading ? ['fa-spinner', 'fa-spin'] : ['fa-download'];
     return (
       <Button
         className={['btn-outline-primary', 'download-btn']}
-        disabled={csvLoading}
+        disabled={disabled || csvLoading}
         label={
           <span>
             <Icon className={['fa', 'mr-2'].concat(downloadButtonIconClasses)} />
@@ -35,6 +36,7 @@ class DownloadCsvButton extends React.Component {
 DownloadCsvButton.defaultProps = {
   csvLoading: false,
   fetchMethod: () => {},
+  disabled: false,
 };
 
 DownloadCsvButton.propTypes = {
@@ -48,6 +50,7 @@ DownloadCsvButton.propTypes = {
       slug: PropTypes.string,
     }).isRequired,
   }).isRequired,
+  disabled: PropTypes.bool,
 };
 
 export default DownloadCsvButton;

--- a/src/components/EnrolledLearnersForInactiveCoursesTable/EnrolledLearnersForInactiveCoursesTable.test.jsx
+++ b/src/components/EnrolledLearnersForInactiveCoursesTable/EnrolledLearnersForInactiveCoursesTable.test.jsx
@@ -10,7 +10,7 @@ import EnrolledLearnersForInactiveCoursesTable from '.';
 const mockStore = configureMockStore([thunk]);
 const enrolledLearnersForInactiveCoursesEmptyStore = mockStore({
   table: {
-    'enrolled-learners-for-inactive-courses': {
+    'enrolled-learners-inactive-courses': {
       data: {
         results: [],
         current_page: 1,
@@ -24,7 +24,7 @@ const enrolledLearnersForInactiveCoursesEmptyStore = mockStore({
 });
 const enrolledLearnersForInactiveCoursesStore = mockStore({
   table: {
-    'enrolled-learners-for-inactive-courses': {
+    'enrolled-learners-inactive-courses': {
       data: {
         count: 3,
         num_pages: 1,
@@ -120,7 +120,7 @@ describe('EnrolledLearnersForInactiveCoursesTable', () => {
   });
 
   it('renders enrolled learners for inactive courses table with correct data', () => {
-    const tableId = 'enrolled-learners-for-inactive-courses';
+    const tableId = 'enrolled-learners-inactive-courses';
     const columnTitles = [
       'Email', 'Total Course Enrollment Count', 'Total Completed Courses Count', 'Last Activity Date',
     ];

--- a/src/components/EnrolledLearnersForInactiveCoursesTable/__snapshots__/EnrolledLearnersForInactiveCoursesTable.test.jsx.snap
+++ b/src/components/EnrolledLearnersForInactiveCoursesTable/__snapshots__/EnrolledLearnersForInactiveCoursesTable.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`EnrolledLearnersForInactiveCoursesTable renders empty state correctly 1
 exports[`EnrolledLearnersForInactiveCoursesTable renders enrolled learners for inactive courses table correctly 1`] = `
 <div>
   <div
-    className="enrolled-learners-for-inactive-courses"
+    className="enrolled-learners-inactive-courses"
   >
     <div
       className="row"
@@ -257,7 +257,7 @@ exports[`EnrolledLearnersForInactiveCoursesTable renders enrolled learners for i
         className="col d-flex justify-content-center"
       >
         <nav
-          aria-label="enrolled-learners-for-inactive-courses-pagination"
+          aria-label="enrolled-learners-inactive-courses-pagination"
           className=""
         >
           <div

--- a/src/components/EnrolledLearnersForInactiveCoursesTable/index.jsx
+++ b/src/components/EnrolledLearnersForInactiveCoursesTable/index.jsx
@@ -37,8 +37,8 @@ const EnrolledLearnersForInactiveCoursesTable = () => {
 
   return (
     <TableContainer
-      id="enrolled-learners-for-inactive-courses"
-      className="enrolled-learners-for-inactive-courses"
+      id="enrolled-learners-inactive-courses"
+      className="enrolled-learners-inactive-courses"
       fetchMethod={EnterpriseDataApiService.fetchEnrolledLearnersForInactiveCourses}
       columns={tableColumns}
       formatData={formatLearnerData}

--- a/src/components/EnrollmentsTable/EnrollmentsTable.mocks.js
+++ b/src/components/EnrollmentsTable/EnrollmentsTable.mocks.js
@@ -1,3 +1,4 @@
+/* istanbul ignore next */
 const mockEnrollmentFetchResponse = {
   count: 330,
   current_page: 1,

--- a/src/components/LearnerActivityTable/index.jsx
+++ b/src/components/LearnerActivityTable/index.jsx
@@ -5,59 +5,67 @@ import TableContainer from '../../containers/TableContainer';
 import { formatTimestamp, formatPassedTimestamp, formatPercentage } from '../../utils';
 import EnterpriseDataApiService from '../../data/services/EnterpriseDataApiService';
 
-const LearnerActivityTable = (props) => {
-  const { activity, id } = props;
-  const tableColumns = [
-    {
-      label: 'Email',
-      key: 'user_email',
-      columnSortable: true,
-    },
-    {
-      label: 'Course Title',
-      key: 'course_title',
-      columnSortable: true,
-    },
-    {
-      label: 'Course Price',
-      key: 'course_price',
-      columnSortable: true,
-    },
-    {
-      label: 'Start Date',
-      key: 'course_start',
-      columnSortable: true,
-    },
-    {
-      label: 'End Date',
-      key: 'course_end',
-      columnSortable: true,
-    },
-    {
-      label: 'Passed Date',
-      key: 'passed_timestamp',
-      columnSortable: true,
-    },
-    {
-      label: 'Current Grade',
-      key: 'current_grade',
-      columnSortable: true,
-    },
-    {
-      label: 'Last Activity Date',
-      key: 'last_activity_date',
-      columnSortable: true,
-    },
-  ];
+class LearnerActivityTable extends React.Component {
+  componentDidUpdate(prevProps) {
+    const { id } = this.props;
 
-  const getTableColumns = () => {
+    if (id && id !== prevProps.id) {
+      this.props.clearTable(prevProps.id);
+    }
+  }
+
+  getTableColumns() {
+    const { activity } = this.props;
+    const tableColumns = [
+      {
+        label: 'Email',
+        key: 'user_email',
+        columnSortable: true,
+      },
+      {
+        label: 'Course Title',
+        key: 'course_title',
+        columnSortable: true,
+      },
+      {
+        label: 'Course Price',
+        key: 'course_price',
+        columnSortable: true,
+      },
+      {
+        label: 'Start Date',
+        key: 'course_start',
+        columnSortable: true,
+      },
+      {
+        label: 'End Date',
+        key: 'course_end',
+        columnSortable: true,
+      },
+      {
+        label: 'Passed Date',
+        key: 'passed_timestamp',
+        columnSortable: true,
+      },
+      {
+        label: 'Current Grade',
+        key: 'current_grade',
+        columnSortable: true,
+      },
+      {
+        label: 'Last Activity Date',
+        key: 'last_activity_date',
+        columnSortable: true,
+      },
+    ];
+
     if (activity !== 'active_past_week') {
       return tableColumns.filter(column => column.key !== 'passed_timestamp');
     }
     return tableColumns;
-  };
+  }
 
-  const formatTableData = enrollments => enrollments.map(enrollment => ({
+  formatTableData = enrollments => enrollments.map(enrollment => ({
     ...enrollment,
     last_activity_date: formatTimestamp({ timestamp: enrollment.last_activity_date }),
     course_start: formatTimestamp({ timestamp: enrollment.course_start }),
@@ -74,24 +82,33 @@ const LearnerActivityTable = (props) => {
     current_grade: formatPercentage({ decimal: enrollment.current_grade }),
   }));
 
-  return (
-    <TableContainer
-      id={id}
-      className={id}
-      fetchMethod={options => EnterpriseDataApiService.fetchCourseEnrollments({
-        learner_activity: activity,
-        ...options,
-      })}
-      columns={getTableColumns()}
-      formatData={formatTableData}
-      tableSortable
-    />
-  );
+  render() {
+    const { activity, id } = this.props;
+
+    return (
+      <TableContainer
+        id={id}
+        className={id}
+        fetchMethod={options => EnterpriseDataApiService.fetchCourseEnrollments({
+          learner_activity: activity,
+          ...options,
+        })}
+        columns={this.getTableColumns()}
+        formatData={this.formatTableData}
+        tableSortable
+      />
+    );
+  }
+}
+
+LearnerActivityTable.defaultProps = {
+  clearTable: () => {},
 };
 
 LearnerActivityTable.propTypes = {
   id: PropTypes.string.isRequired,
   activity: PropTypes.string.isRequired,
+  clearTable: PropTypes.func,
 };
 
 export default LearnerActivityTable;

--- a/src/components/PastWeekPassedLearnersTable/PastWeekPassedLearnersTable.test.jsx
+++ b/src/components/PastWeekPassedLearnersTable/PastWeekPassedLearnersTable.test.jsx
@@ -10,7 +10,7 @@ import PastWeekPassedLearnersTable from '.';
 const mockStore = configureMockStore([thunk]);
 const store = mockStore({
   table: {
-    'past-week-passed-learners': {
+    'completed-learners-week': {
       data: {
         count: 2,
         num_pages: 1,
@@ -64,6 +64,7 @@ describe('PastWeekPassedLearnersTable', () => {
   });
 
   it('renders table with correct data', () => {
+    const tableId = 'completed-learners-week';
     const columnTitles = ['Email', 'Course Title', 'Passed Date'];
     const rowsData = [
       [
@@ -83,18 +84,18 @@ describe('PastWeekPassedLearnersTable', () => {
     ));
 
     // Verify that table has correct number of columns
-    expect(wrapper.find('.past-week-passed-learners thead th').length).toEqual(3);
+    expect(wrapper.find(`.${tableId} thead th`).length).toEqual(3);
 
     // Verify only expected columns are shown
-    wrapper.find('.past-week-passed-learners thead th').forEach((column, index) => {
+    wrapper.find(`.${tableId} thead th`).forEach((column, index) => {
       expect(column.text()).toContain(columnTitles[index]);
     });
 
     // Verify that table has correct number of rows
-    expect(wrapper.find('.past-week-passed-learners tbody tr').length).toEqual(2);
+    expect(wrapper.find(`.${tableId} tbody tr`).length).toEqual(2);
 
     // Verify each row in table has correct data
-    wrapper.find('.past-week-passed-learners tbody tr').forEach((row, rowIndex) => {
+    wrapper.find(`.${tableId} tbody tr`).forEach((row, rowIndex) => {
       row.find('td').forEach((cell, colIndex) => {
         expect(cell.text()).toEqual(rowsData[rowIndex][colIndex]);
       });

--- a/src/components/PastWeekPassedLearnersTable/__snapshots__/PastWeekPassedLearnersTable.test.jsx.snap
+++ b/src/components/PastWeekPassedLearnersTable/__snapshots__/PastWeekPassedLearnersTable.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`PastWeekPassedLearnersTable renders table correctly 1`] = `
 <div>
   <div
-    className="past-week-passed-learners"
+    className="completed-learners-week"
   >
     <div
       className="row"
@@ -159,7 +159,7 @@ exports[`PastWeekPassedLearnersTable renders table correctly 1`] = `
         className="col d-flex justify-content-center"
       >
         <nav
-          aria-label="past-week-passed-learners-pagination"
+          aria-label="completed-learners-week-pagination"
           className=""
         >
           <div

--- a/src/components/PastWeekPassedLearnersTable/index.jsx
+++ b/src/components/PastWeekPassedLearnersTable/index.jsx
@@ -30,8 +30,8 @@ const PastWeekPassedLearnersTable = () => {
 
   return (
     <TableContainer
-      id="past-week-passed-learners"
-      className="past-week-passed-learners"
+      id="completed-learners-week"
+      className="completed-learners-week"
       fetchMethod={options => EnterpriseDataApiService.fetchCourseEnrollments({
         passed_date: 'last_week',
         ...options,

--- a/src/components/RegisteredLearnersTable/RegisteredLearnersTable.test.jsx
+++ b/src/components/RegisteredLearnersTable/RegisteredLearnersTable.test.jsx
@@ -9,7 +9,7 @@ import RegisteredLearnersTable from '.';
 const mockStore = configureMockStore([thunk]);
 const store = mockStore({
   table: {
-    'unenrolled-registered-learners': {
+    'registered-unenrolled-learners': {
       data: {
         results: [],
         current_page: 1,

--- a/src/components/RegisteredLearnersTable/index.jsx
+++ b/src/components/RegisteredLearnersTable/index.jsx
@@ -28,9 +28,9 @@ const RegisteredLearnersTable = () => {
 
   return (
     <TableContainer
-      id="unenrolled-registered-learners"
-      className="unenrolled-registered-learners"
-      fetchMethod={EnterpriseDataApiService.fetchUnerolledRegisteredLearners}
+      id="registered-unenrolled-learners"
+      className="registered-unenrolled-learners"
+      fetchMethod={EnterpriseDataApiService.fetchUnenrolledRegisteredLearners}
       columns={tableColumns}
       formatData={formatLearnerData}
       tableSortable

--- a/src/containers/AdminPage/index.jsx
+++ b/src/containers/AdminPage/index.jsx
@@ -15,6 +15,7 @@ const mapStateToProps = state => ({
   lastUpdatedDate: state.dashboardAnalytics.last_updated_date,
   enterpriseId: state.portalConfiguration.enterpriseId,
   csv: state.csv,
+  table: state.table,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/DownloadCsvButton/DownloadCsvButton.test.jsx
+++ b/src/containers/DownloadCsvButton/DownloadCsvButton.test.jsx
@@ -37,7 +37,9 @@ describe('<DownloadCsvButton />', () => {
   });
 
   it('fetchCsv dispatch action', () => {
-    wrapper.props().fetchCsv(EnterpriseDataApiService.fetchCourseEnrollmentsCsv);
+    wrapper.props().fetchCsv(() => (
+      EnterpriseDataApiService.fetchCourseEnrollments({}, { csv: true })
+    ));
     expect(dispatchSpy).toHaveBeenCalled();
   });
 });

--- a/src/containers/LearnerActivityTable/index.jsx
+++ b/src/containers/LearnerActivityTable/index.jsx
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+
+import LearnerActivityTable from '../../components/LearnerActivityTable';
+import { clearTable } from '../../data/actions/table';
+
+const mapDispatchToProps = dispatch => ({
+  clearTable: (tableId) => {
+    dispatch(clearTable(tableId));
+  },
+});
+
+export default connect(null, mapDispatchToProps)(LearnerActivityTable);

--- a/src/data/services/EnterpriseDataApiService.js
+++ b/src/data/services/EnterpriseDataApiService.js
@@ -10,121 +10,83 @@ class EnterpriseDataApiService {
   // TODO: This should access the data-api through the gateway instead of direct
   static enterpriseBaseUrl = `${configuration.DATA_API_BASE_URL}/enterprise/api/v0/enterprise/`;
 
-  static fetchCourseEnrollments(options) {
-    const { enterpriseId } = store.getState().portalConfiguration;
-    const queryParams = {
-      page: 1,
-      page_size: 50,
-      ...options,
-    };
-
-    const enrollmentsUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/enrollments/?${qs.stringify(queryParams)}`;
-    const jwtToken = getAccessToken();
-
-    return httpClient.get(enrollmentsUrl, {
-      headers: {
-        Authorization: `JWT ${jwtToken}`,
-      },
-    });
-  }
-
-  static fetchCourseEnrollmentsCsv(enterpriseId) {
-    const csvUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/enrollments.csv/?no_page=true`;
-    const jwtToken = getAccessToken();
-    return httpClient.get(csvUrl, {
-      headers: {
-        Authorization: `JWT ${jwtToken}`,
-      },
-    });
-  }
-
   static fetchDashboardAnalytics(enterpriseId) {
-    const analyticsUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/enrollments/overview/`;
+    const url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/enrollments/overview/`;
     const jwtToken = getAccessToken();
 
-    return httpClient.get(analyticsUrl, {
+    return httpClient.get(url, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },
     });
   }
 
-  static fetchUnerolledRegisteredLearners(options) {
+  static fetchCourseEnrollments(options, { csv } = {}) {
     const { enterpriseId } = store.getState().portalConfiguration;
+    const endpoint = csv ? 'enrollments.csv' : 'enrollments';
+    const queryParams = {
+      page: 1,
+      page_size: 50,
+      no_page: csv,
+      ...options,
+    };
+
+    const url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/${endpoint}/?${qs.stringify(queryParams)}`;
+    const jwtToken = getAccessToken();
+
+    return httpClient.get(url, {
+      headers: {
+        Authorization: `JWT ${jwtToken}`,
+      },
+    });
+  }
+
+  static fetchUnenrolledRegisteredLearners(options, { csv } = {}) {
+    const { enterpriseId } = store.getState().portalConfiguration;
+    const endpoint = csv ? 'users.csv' : 'users';
     const queryParams = {
       page: 1,
       page_size: 50,
       has_enrollments: false,
+      no_page: csv,
       ...options,
     };
 
-    const analyticsUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/users/?${qs.stringify(queryParams)}`;
+    const url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/${endpoint}/?${qs.stringify(queryParams)}`;
     const jwtToken = getAccessToken();
 
-    return httpClient.get(analyticsUrl, {
+    return httpClient.get(url, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },
     });
   }
 
-  // TODO wire this up with generic DownloadCsvButton component
-  static fetchUnerolledRegisteredLearnersCsv() {
+  static fetchEnrolledLearners(options, { csv } = {}) {
     const { enterpriseId } = store.getState().portalConfiguration;
-    const jwtToken = getAccessToken();
-    const queryParams = {
-      has_enrollments: false,
-      no_page: true,
-    };
-    const csvUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/users.csv/?${qs.stringify(queryParams)}`;
-
-    return httpClient.get(csvUrl, {
-      headers: {
-        Authorization: `JWT ${jwtToken}`,
-      },
-    });
-  }
-
-  static fetchEnrolledLearners(options) {
-    const { enterpriseId } = store.getState().portalConfiguration;
+    const endpoint = csv ? 'users.csv' : 'users';
     const queryParams = {
       page: 1,
       page_size: 50,
       has_enrollments: true,
       extra_fields: ['enrollment_count'],
+      no_page: csv,
       ...options,
     };
 
-    const analyticsUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/users/?${qs.stringify(queryParams)}`;
+    const url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/${endpoint}/?${qs.stringify(queryParams)}`;
     const jwtToken = getAccessToken();
 
-    return httpClient.get(analyticsUrl, {
+    return httpClient.get(url, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },
     });
   }
 
-  // TODO wire this up with generic DownloadCsvButton component
-  static fetchEnrolledLearnersCsv() {
+  static fetchEnrolledLearnersForInactiveCourses(options, { csv } = {}) {
     const { enterpriseId } = store.getState().portalConfiguration;
-    const jwtToken = getAccessToken();
-    const queryParams = {
-      has_enrollments: true,
-      extra_fields: ['enrollment_count'],
-      no_page: true,
-    };
-    const csvUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/users.csv/?${qs.stringify(queryParams)}`;
-
-    return httpClient.get(csvUrl, {
-      headers: {
-        Authorization: `JWT ${jwtToken}`,
-      },
-    });
-  }
-
-  static fetchEnrolledLearnersForInactiveCourses(options) {
-    const { enterpriseId } = store.getState().portalConfiguration;
+    const endpoint = csv ? 'users.csv' : 'users';
     const queryParams = {
       page: 1,
       page_size: 50,
@@ -132,66 +94,34 @@ class EnterpriseDataApiService {
       active_courses: false,
       all_enrollments_passed: true,
       extra_fields: ['enrollment_count', 'course_completion_count'],
+      no_page: csv,
       ...options,
     };
 
-    const analyticsUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/users/?${qs.stringify(queryParams)}`;
+    const url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/${endpoint}/?${qs.stringify(queryParams)}`;
     const jwtToken = getAccessToken();
 
-    return httpClient.get(analyticsUrl, {
+    return httpClient.get(url, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },
     });
   }
 
-  static fetchEnrolledLearnersForInactiveCoursesCsv() {
+  static fetchCompletedLearners(options, { csv } = {}) {
     const { enterpriseId } = store.getState().portalConfiguration;
-    const jwtToken = getAccessToken();
-    const queryParams = {
-      has_enrollments: true,
-      active_courses: false,
-      all_enrollments_passed: true,
-      extra_fields: ['enrollment_count', 'course_completion_count'],
-      no_page: true,
-    };
-    const csvUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/users.csv/?${qs.stringify(queryParams)}`;
-
-    return httpClient.get(csvUrl, {
-      headers: {
-        Authorization: `JWT ${jwtToken}`,
-      },
-    });
-  }
-
-  static fetchCompletedLearners(options) {
-    const { enterpriseId } = store.getState().portalConfiguration;
+    const endpoint = csv ? 'learner_completed_courses.csv' : 'learner_completed_courses';
     const queryParams = {
       page: 1,
       page_size: 50,
+      no_page: csv,
       ...options,
     };
 
-    const analyticsUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/learner_completed_courses/?${qs.stringify(queryParams)}`;
+    const url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/${endpoint}/?${qs.stringify(queryParams)}`;
     const jwtToken = getAccessToken();
 
-    return httpClient.get(analyticsUrl, {
-      headers: {
-        Authorization: `JWT ${jwtToken}`,
-      },
-    });
-  }
-
-  // TODO wire this up with generic DownloadCsvButton component
-  static fetchCompletedLearnersCsv() {
-    const { enterpriseId } = store.getState().portalConfiguration;
-    const jwtToken = getAccessToken();
-    const queryParams = {
-      no_page: true,
-    };
-    const csvUrl = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/learner_completed_courses.csv/?${qs.stringify(queryParams)}`;
-
-    return httpClient.get(csvUrl, {
+    return httpClient.get(url, {
       headers: {
         Authorization: `JWT ${jwtToken}`,
       },


### PR DESCRIPTION
1. Ensures each card action table has an associated csv fetch method;
2. Refactors the `EnterpriseDataApiService` so that we don't have two methods (i.e., one for normal and one for csv) for every request; instead, supports passing a `csv` boolean flag to the fetch method for it to fetch the csv.
3. Refactors the logic around when the csv button is disabled:
    - Disables whenever the table data is loading (to prevent accidentally downloading a csv while a different table is loading);
    - Disables if there are no results in the table (no reason to let users download if there's no data to download).
4. Updates the `LearnerActivityTable` to clear it's associated Redux state whenever the `id` prop changes.
    - This is necessary because this component is used for 3 of the card action tables. When switching between these 3 tables, the state never gets cleared so the loading flags were not accurate.