### PR TITLE
Fix failing test for demo data

### DIFF
--- a/src/demo/rewireEnterpriseDataApiService.test.js
+++ b/src/demo/rewireEnterpriseDataApiService.test.js
@@ -102,7 +102,7 @@ describe('rewireEnterpriseDataApiService', () => {
         },
         course_completions: expect.any(Number),
         enrolled_learners: expect.any(Number),
-        last_update_date: expect.any(Date),
+        last_updated_date: expect.any(String),
         number_of_users: expect.any(Number),
       };
       expect(results.data).toEqual(expectedResults);


### PR DESCRIPTION
I noticed this test on `master` was failing after @mushtaqak merged his demo data changes. The reason why it was failing is because the `last_updated_date` was a string, but we were checking to verify it as a `Date` object. `last_updated_date` changed to be a string when I had Mushtaq add `.toString()` to the date as the last updated date wasn't showing in the UI otherwise.

Also, this test had the key `last_update_date`, not `last_updated_date`.

Still TBD how the test was passing on @mushtaqak branch.