### PR TITLE
Minor DownloadCsvButton refactor

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -98,9 +98,7 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download full report (CSV)
               </span>
             </button>
           </div>
@@ -400,9 +398,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download current report (CSV)
               </span>
             </button>
           </div>
@@ -702,9 +698,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download current report (CSV)
               </span>
             </button>
           </div>
@@ -1009,9 +1003,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download current report (CSV)
               </span>
             </button>
           </div>
@@ -1562,9 +1554,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download full report (CSV)
               </span>
             </button>
           </div>
@@ -1847,9 +1837,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download full report (CSV)
               </span>
             </button>
           </div>
@@ -2154,9 +2142,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download current report (CSV)
               </span>
             </button>
           </div>
@@ -2461,9 +2447,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download current report (CSV)
               </span>
             </button>
           </div>
@@ -2766,9 +2750,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download current report (CSV)
               </span>
             </button>
           </div>
@@ -3068,9 +3050,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download current report (CSV)
               </span>
             </button>
           </div>
@@ -3375,9 +3355,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                     id="Icon1"
                   />
                 </span>
-                Download 
-                full
-                 report (CSV)
+                Download current report (CSV)
               </span>
             </button>
           </div>

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -278,6 +278,7 @@ class Admin extends React.Component {
                       id={tableMetadata.csvButtonId}
                       fetchMethod={tableMetadata.csvFetchMethod}
                       disabled={this.shouldDisableCsvButton(actionSlug)}
+                      buttonLabel={`Download ${actionSlug ? 'current' : 'full'} report (CSV)`}
                     />
                   </div>
                 </div>

--- a/src/components/DownloadCsvButton/index.jsx
+++ b/src/components/DownloadCsvButton/index.jsx
@@ -12,10 +12,9 @@ class DownloadCsvButton extends React.Component {
       fetchMethod,
       fetchCsv,
       csvLoading,
-      match,
       disabled,
+      buttonLabel,
     } = this.props;
-    const { params: { slug } } = match;
     const downloadButtonIconClasses = csvLoading ? ['fa-spinner', 'fa-spin'] : ['fa-download'];
     return (
       <Button
@@ -24,7 +23,7 @@ class DownloadCsvButton extends React.Component {
         label={
           <span>
             <Icon className={['fa', 'mr-2'].concat(downloadButtonIconClasses)} />
-            Download {slug ? 'current' : 'full'} report (CSV)
+            {buttonLabel}
           </span>
         }
         onClick={() => fetchCsv(fetchMethod)}
@@ -37,6 +36,7 @@ DownloadCsvButton.defaultProps = {
   csvLoading: false,
   fetchMethod: () => {},
   disabled: false,
+  buttonLabel: 'Download report (CSV)',
 };
 
 DownloadCsvButton.propTypes = {
@@ -44,13 +44,8 @@ DownloadCsvButton.propTypes = {
   fetchMethod: PropTypes.func,
   csvLoading: PropTypes.bool,
   clearCsv: PropTypes.func.isRequired,
-  match: PropTypes.shape({
-    url: PropTypes.string.isRequired,
-    params: PropTypes.shape({
-      slug: PropTypes.string,
-    }).isRequired,
-  }).isRequired,
   disabled: PropTypes.bool,
+  buttonLabel: PropTypes.string,
 };
 
 export default DownloadCsvButton;

--- a/src/containers/DownloadCsvButton/index.jsx
+++ b/src/containers/DownloadCsvButton/index.jsx
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 
 import { fetchCsv, clearCsv } from '../../data/actions/csv';
 import DownloadCsvButton from '../../components/DownloadCsvButton';
@@ -20,4 +19,4 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   },
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DownloadCsvButton));
+export default connect(mapStateToProps, mapDispatchToProps)(DownloadCsvButton);


### PR DESCRIPTION
Updates the `DownloadCsvButton` component to accept a `buttonLabel` prop such that the logic around the button label text is determined by the consuming component.

Before, the text displayed was dependent on the `actionSlug` URL parameter which doesn't make sense to couple in a generic download csv button component.