### PR TITLE
Fixing table id for learners-active-week

### DIFF
--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -86,7 +86,7 @@ class Admin extends React.Component {
       'learners-active-week': {
         title: 'Learners Enrolled in a Course',
         subtitle: 'Top Active Learners',
-        component: <LearnerActivityTable id="active-week" activity="active_past_week" />,
+        component: <LearnerActivityTable id="learners-active-week" activity="active_past_week" />,
         csvFetchMethod: () => (
           EnterpriseDataApiService.fetchCourseEnrollments({ learner_activity: 'active_past_week' }, { csv: true })
         ),


### PR DESCRIPTION
I noticed for one of the card actions, the csv button was always disabled. This is happening because the logic for whether the csv button should be disabled checks to see if there is any table data. It couldn't find the table data in question because the key it uses to do the lookup doesn't match the table id.

Currently, the table id and csv button id must be the same. In this case, the csv button id was different than the table id. This PR updates the table id so that the logic for disabling the CSV button works correctly for the "top active learners" report.