### PR TITLE
Fixing unresolved promise rejection

### DIFF
--- a/src/demo/rewireEnterpriseDataApiService.test.js
+++ b/src/demo/rewireEnterpriseDataApiService.test.js
@@ -93,19 +93,21 @@ describe('rewireEnterpriseDataApiService', () => {
   });
 
   describe('fetchDashboardAnalytics', () => {
-    rewire();
-    return EnterpriseDataApiService.fetchDashboardAnalytics().then((results) => {
-      const expectedResults = {
-        active_learners: {
-          past_month: expect.any(Number),
-          past_week: expect.any(Number),
-        },
-        course_completions: expect.any(Number),
-        enrolled_learners: expect.any(Number),
-        last_updated_date: expect.any(String),
-        number_of_users: expect.any(Number),
-      };
-      expect(results.data).toEqual(expectedResults);
+    it('rewires fetchDashboardAnalytics', () => {
+      rewire();
+      return EnterpriseDataApiService.fetchDashboardAnalytics().then((results) => {
+        const expectedResults = {
+          active_learners: {
+            past_month: expect.any(Number),
+            past_week: expect.any(Number),
+          },
+          course_completions: expect.any(Number),
+          enrolled_learners: expect.any(Number),
+          last_updated_date: expect.any(String),
+          number_of_users: expect.any(Number),
+        };
+        expect(results.data).toEqual(expectedResults);
+      });
     });
   });
 });

--- a/src/demo/rewireEnterpriseDataApiService.test.js
+++ b/src/demo/rewireEnterpriseDataApiService.test.js
@@ -12,6 +12,21 @@ describe('rewireEnterpriseDataApiService', () => {
     fetchDashboardAnalytics,
   } = EnterpriseDataApiService;
 
+  const verifyFetchMethod = (fetchMethod, options = {}) => fetchMethod(options).then((results) => {
+    // Only testing for data types, not actual values
+    const expectedResults = {
+      count: expect.any(Number),
+      num_pages: expect.any(Number),
+      current_page: expect.any(Number),
+      results: expect.any(Array),
+    };
+    expect(results.data).toEqual(expectedResults);
+  });
+
+  beforeEach(() => {
+    rewire();
+  });
+
   afterEach(() => {
     // rewire in the tests overrides the methods on EnterpriseDataApiService so we restore
     // them to their original method calls after each test. Ideally we would just save/restore
@@ -25,89 +40,55 @@ describe('rewireEnterpriseDataApiService', () => {
     EnterpriseDataApiService.fetchDashboardAnalytics = fetchDashboardAnalytics;
   });
 
-  describe('fetchEnrollments', () => {
-    const verifyFetchMethodEnrollments = (fetchMethod, options = {}) => fetchMethod(options).then((results) => { // eslint-disable-line max-len
-      // Only testing for data types, not actual values
+  it('rewires fetchCourseEnrollments call', () => verifyFetchMethod(EnterpriseDataApiService.fetchCourseEnrollments));
+
+  it('rewires fetchCourseEnrollments with options call', () =>
+    verifyFetchMethod(
+      EnterpriseDataApiService.fetchCourseEnrollments,
+      {
+        learner_activity: 'active_past_week',
+      },
+    ));
+
+  it('rewires fetchEnrolledLearners call', () => verifyFetchMethod(EnterpriseDataApiService.fetchEnrolledLearners));
+
+  it('rewires filterEnrolledLearnersForInactiveCourses call', () => verifyFetchMethod(EnterpriseDataApiService.fetchEnrolledLearnersForInactiveCourses));
+
+  it('rewires fetchUnenrolledRegisteredLearners call', () => verifyFetchMethod(EnterpriseDataApiService.fetchUnenrolledRegisteredLearners));
+
+  it('rewires fetchCompletedLearners call', () => verifyFetchMethod(EnterpriseDataApiService.fetchCompletedLearners));
+
+  it('rewires fetchCourseEnrollmentsCsv call', () =>
+    EnterpriseDataApiService.fetchCourseEnrollmentsCsv().then((results) => {
+      expect(results.data).toEqual(expect.any(String));
+    }));
+
+  it('rewires fetchDashboardAnalytics', () =>
+    EnterpriseDataApiService.fetchDashboardAnalytics().then((results) => {
       const expectedResults = {
-        count: expect.any(Number),
-        num_pages: expect.any(Number),
-        current_page: expect.any(Number),
-        results: expect.any(Array),
+        active_learners: {
+          past_month: expect.any(Number),
+          past_week: expect.any(Number),
+        },
+        course_completions: expect.any(Number),
+        enrolled_learners: expect.any(Number),
+        last_updated_date: expect.any(String),
+        number_of_users: expect.any(Number),
       };
       expect(results.data).toEqual(expectedResults);
-    });
-    it('rewires fetchCourseEnrollments call', () => {
-      rewire();
-      return verifyFetchMethodEnrollments(EnterpriseDataApiService.fetchCourseEnrollments);
-    });
-    it('rewires fetchCourseEnrollments with options call', () => {
-      rewire();
-      return verifyFetchMethodEnrollments(
-        EnterpriseDataApiService.fetchCourseEnrollments,
-        {
-          learner_activity: 'active_past_week',
-        },
-      );
-    });
-    it('rewires fetchEnrolledLearners call', () => {
-      rewire();
-      return verifyFetchMethodEnrollments(EnterpriseDataApiService.fetchEnrolledLearners);
-    });
-    it('rewires filterEnrolledLearnersForInactiveCourses call', () => {
-      rewire();
-      return verifyFetchMethodEnrollments(EnterpriseDataApiService.fetchEnrolledLearnersForInactiveCourses); // eslint-disable-line max-len
-    });
-    it('rewires fetchUnenrolledRegisteredLearners call', () => {
-      rewire();
-      return verifyFetchMethodEnrollments(EnterpriseDataApiService.fetchUnenrolledRegisteredLearners); // eslint-disable-line max-len
-    });
-    it('rewires fetchCompletedLearners call', () => {
-      rewire();
-      return verifyFetchMethodEnrollments(EnterpriseDataApiService.fetchCompletedLearners);
-    });
-    it('supports sorting via options', () => {
-      rewire();
-      return EnterpriseDataApiService.fetchCourseEnrollments({ ordering: 'current_grade' }).then((results) => {
-        let previous = results.data.results[0];
-        results.data.results.forEach((enrollment) => {
-          expect(enrollment.current_grade).toBeGreaterThanOrEqual(previous.current_grade);
-          previous = enrollment;
-        });
-      });
-    });
-    it('supports pagination via options', () => {
-      rewire();
-      return EnterpriseDataApiService.fetchCourseEnrollments({ page: 2 }).then((results) => {
-        expect(results.data.current_page).toEqual(2);
-      });
-    });
-  });
+    }));
 
-  describe('fetchCourseEnrollmentsCsv', () => {
-    it('rewires fetchCourseEnrollmentsCsv call', () => {
-      rewire();
-      return EnterpriseDataApiService.fetchCourseEnrollmentsCsv().then((results) => {
-        expect(results.data).toEqual(expect.any(String));
+  it('supports sorting via options', () =>
+    EnterpriseDataApiService.fetchCourseEnrollments({ ordering: 'current_grade' }).then((results) => {
+      let previous = results.data.results[0];
+      results.data.results.forEach((enrollment) => {
+        expect(enrollment.current_grade).toBeGreaterThanOrEqual(previous.current_grade);
+        previous = enrollment;
       });
-    });
-  });
+    }));
 
-  describe('fetchDashboardAnalytics', () => {
-    it('rewires fetchDashboardAnalytics', () => {
-      rewire();
-      return EnterpriseDataApiService.fetchDashboardAnalytics().then((results) => {
-        const expectedResults = {
-          active_learners: {
-            past_month: expect.any(Number),
-            past_week: expect.any(Number),
-          },
-          course_completions: expect.any(Number),
-          enrolled_learners: expect.any(Number),
-          last_updated_date: expect.any(String),
-          number_of_users: expect.any(Number),
-        };
-        expect(results.data).toEqual(expectedResults);
-      });
-    });
-  });
+  it('supports pagination via options', () =>
+    EnterpriseDataApiService.fetchCourseEnrollments({ page: 2 }).then((results) => {
+      expect(results.data.current_page).toEqual(2);
+    }));
 });


### PR DESCRIPTION
An "unresolved promise rejection" warning was happening for the `fetchDashboardAnalytics` test in `rewireEnterpriseDataApiService.test.js` but the test was not actually failing, which is why we didn't catch it.

The reason for the error occurring was because the test in question was within a `describe` block but missing the nested `it` block. Adding the `it` block ensures that the test actually fails if the `expect`'s don't match without the "unresolved promise rejection" warning.

Also, I moved around the tests to:
* Add the `rewire()` call in the `beforeEach()`
* Remove unnecessary `describe` blocks.