### PR TITLE
Update NumberCard details toggle button

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -1131,30 +1131,36 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                 className="card-footer"
               >
                 <div
-                  className="footer-title d-flex justify-content-between align-items-center"
+                  className="footer-title"
                 >
-                  <span>
-                    Details
-                  </span>
                   <button
-                    className="btn toggle-collapse btn-link"
+                    className="btn toggle-collapse btn-block"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <span>
+                    <div
+                      className="d-flex justify-content-between align-items-center"
+                    >
                       <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon1"
-                      />
-                      <span
-                        className="sr-only"
+                        className="details-btn-text"
                       >
-                        Show details
+                        Details
                       </span>
-                    </span>
+                      <span>
+                        <span
+                          aria-hidden={true}
+                          className="fa fa-caret-down"
+                          id="Icon1"
+                        />
+                        <span
+                          className="sr-only"
+                        >
+                          Show details
+                        </span>
+                      </span>
+                    </div>
                   </button>
                 </div>
                 <div
@@ -1217,30 +1223,36 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                 className="card-footer"
               >
                 <div
-                  className="footer-title d-flex justify-content-between align-items-center"
+                  className="footer-title"
                 >
-                  <span>
-                    Details
-                  </span>
                   <button
-                    className="btn toggle-collapse btn-link"
+                    className="btn toggle-collapse btn-block"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <span>
+                    <div
+                      className="d-flex justify-content-between align-items-center"
+                    >
                       <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon1"
-                      />
-                      <span
-                        className="sr-only"
+                        className="details-btn-text"
                       >
-                        Show details
+                        Details
                       </span>
-                    </span>
+                      <span>
+                        <span
+                          aria-hidden={true}
+                          className="fa fa-caret-down"
+                          id="Icon1"
+                        />
+                        <span
+                          className="sr-only"
+                        >
+                          Show details
+                        </span>
+                      </span>
+                    </div>
                   </button>
                 </div>
                 <div
@@ -1319,30 +1331,36 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                 className="card-footer"
               >
                 <div
-                  className="footer-title d-flex justify-content-between align-items-center"
+                  className="footer-title"
                 >
-                  <span>
-                    Details
-                  </span>
                   <button
-                    className="btn toggle-collapse btn-link"
+                    className="btn toggle-collapse btn-block"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <span>
+                    <div
+                      className="d-flex justify-content-between align-items-center"
+                    >
                       <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon1"
-                      />
-                      <span
-                        className="sr-only"
+                        className="details-btn-text"
                       >
-                        Show details
+                        Details
                       </span>
-                    </span>
+                      <span>
+                        <span
+                          aria-hidden={true}
+                          className="fa fa-caret-down"
+                          id="Icon1"
+                        />
+                        <span
+                          className="sr-only"
+                        >
+                          Show details
+                        </span>
+                      </span>
+                    </div>
                   </button>
                 </div>
                 <div
@@ -1437,30 +1455,36 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                 className="card-footer"
               >
                 <div
-                  className="footer-title d-flex justify-content-between align-items-center"
+                  className="footer-title"
                 >
-                  <span>
-                    Details
-                  </span>
                   <button
-                    className="btn toggle-collapse btn-link"
+                    className="btn toggle-collapse btn-block"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <span>
+                    <div
+                      className="d-flex justify-content-between align-items-center"
+                    >
                       <span
-                        aria-hidden={true}
-                        className="fa fa-caret-down"
-                        id="Icon1"
-                      />
-                      <span
-                        className="sr-only"
+                        className="details-btn-text"
                       >
-                        Show details
+                        Details
                       </span>
-                    </span>
+                      <span>
+                        <span
+                          aria-hidden={true}
+                          className="fa fa-caret-down"
+                          id="Icon1"
+                        />
+                        <span
+                          className="sr-only"
+                        >
+                          Show details
+                        </span>
+                      </span>
+                    </div>
                   </button>
                 </div>
                 <div

--- a/src/components/NumberCard/NumberCard.scss
+++ b/src/components/NumberCard/NumberCard.scss
@@ -42,7 +42,7 @@ $number-card-box-shadow: 0 .125rem .25rem rgba(0,0,0,.075);
         position: relative;
         font-size: 0.875rem;
         background: #ffffff;
-        padding: 0.75em 0;
+        padding: 0;
         border: $card-border-width solid $card-border-color;
         @include border-radius($card-border-radius);
 
@@ -56,20 +56,18 @@ $number-card-box-shadow: 0 .125rem .25rem rgba(0,0,0,.075);
             }
         }
     
-        .footer-title {
-            font-weight: 600;
-        }
-    
-        .footer-title {
-            padding: 0 1.25rem;
-        }
-    
         .toggle-collapse {
-            color: #005686;
-            padding: 4px;
+            padding: 1rem 1.25rem;
+            font-weight: 600;
+            color: #313131;
+            font-size: 0.875rem;
     
             &:focus {
                 box-shadow: $input-btn-focus-box-shadow;
+            }
+
+            .fa {
+                font-size: 1rem;
             }
         }
     

--- a/src/components/NumberCard/NumberCard.test.jsx
+++ b/src/components/NumberCard/NumberCard.test.jsx
@@ -71,14 +71,14 @@ describe('<NumberCard />', () => {
     });
 
     it('expands and collapses the actions', () => {
-      expect(getNumberCard(wrapper).find('.footer-title > span').text()).toEqual('Details');
+      expect(getNumberCard(wrapper).find('.details-btn-text').text()).toEqual('Details');
 
       wrapper.setProps({ detailsExpanded: true });
-      expect(getNumberCard(wrapper).find('.footer-title > span').text()).toEqual('Detailed breakdown');
+      expect(getNumberCard(wrapper).find('.details-btn-text').text()).toEqual('Detailed breakdown');
       expect(getNumberCard(wrapper).instance().state.detailsExpanded).toBeTruthy();
 
       wrapper.setProps({ detailsExpanded: false });
-      expect(getNumberCard(wrapper).find('.footer-title > span').text()).toEqual('Details');
+      expect(getNumberCard(wrapper).find('.details-btn-text').text()).toEqual('Details');
       expect(getNumberCard(wrapper).instance().state.detailsExpanded).toBeFalsy();
     });
 

--- a/src/components/NumberCard/__snapshots__/NumberCard.test.jsx.snap
+++ b/src/components/NumberCard/__snapshots__/NumberCard.test.jsx.snap
@@ -35,30 +35,36 @@ exports[`<NumberCard /> renders correctly with detail actions 1`] = `
     className="card-footer"
   >
     <div
-      className="footer-title d-flex justify-content-between align-items-center"
+      className="footer-title"
     >
-      <span>
-        Details
-      </span>
       <button
-        className="btn toggle-collapse btn-link"
+        className="btn toggle-collapse btn-block"
         onBlur={[Function]}
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
       >
-        <span>
+        <div
+          className="d-flex justify-content-between align-items-center"
+        >
           <span
-            aria-hidden={true}
-            className="fa fa-caret-down"
-            id="Icon1"
-          />
-          <span
-            className="sr-only"
+            className="details-btn-text"
           >
-            Show details
+            Details
           </span>
-        </span>
+          <span>
+            <span
+              aria-hidden={true}
+              className="fa fa-caret-down"
+              id="Icon1"
+            />
+            <span
+              className="sr-only"
+            >
+              Show details
+            </span>
+          </span>
+        </div>
       </button>
     </div>
     <div

--- a/src/components/NumberCard/index.jsx
+++ b/src/components/NumberCard/index.jsx
@@ -208,25 +208,24 @@ class NumberCard extends React.Component {
         </div>
         {detailActions &&
           <div className="card-footer">
-            <div className="footer-title d-flex justify-content-between align-items-center">
-              <span>
-                {detailsExpanded ? 'Detailed breakdown' : 'Details'}
-              </span>
+            <div className="footer-title">
               <Button
                 inputRef={(node) => { this.toggleDetailsBtnRef = node; }}
-                buttonType="link"
-                className={['toggle-collapse']}
+                className={['toggle-collapse', 'btn-block']}
                 label={
-                  <Icon
-                    className={[classNames(
-                      'fa',
-                      {
-                        'fa-caret-down': !detailsExpanded,
-                        'fa-close': detailsExpanded,
-                      },
-                    )]}
-                    screenReaderText={detailsExpanded ? 'Close details' : 'Show details'}
-                  />
+                  <div className="d-flex justify-content-between align-items-center">
+                    <span className="details-btn-text">{detailsExpanded ? 'Detailed breakdown' : 'Details'}</span>
+                    <Icon
+                      className={[classNames(
+                        'fa',
+                        {
+                          'fa-caret-down': !detailsExpanded,
+                          'fa-close': detailsExpanded,
+                        },
+                      )]}
+                      screenReaderText={detailsExpanded ? 'Close details' : 'Show details'}
+                    />
+                  </div>
                 }
                 onClick={this.toggleDetails}
                 onKeyDown={this.handleToggleDetailsKeyDown}


### PR DESCRIPTION
Right now, the click target is the just the icon to toggle the the expand/collapse of the `NumberCard` actions. This PR refactors the click target to make the entire details add-on clickable so it's easier to click.