### PR TITLE
Use React.Fragment where relevant

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -30,7 +30,7 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -91,15 +91,13 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download full report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download full report (CSV)
             </button>
           </div>
         </div>
@@ -129,12 +127,12 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders # courses enrolled by learners 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -163,7 +161,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -683,15 +681,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download current report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download current report (CSV)
             </button>
           </div>
         </div>
@@ -721,12 +717,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders # of courses completed by learner 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -755,7 +751,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -1275,15 +1271,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download current report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download current report (CSV)
             </button>
           </div>
         </div>
@@ -1313,12 +1307,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders # of courses completed by learner in past week 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -1347,7 +1341,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -1872,15 +1866,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download current report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download current report (CSV)
             </button>
           </div>
         </div>
@@ -1910,12 +1902,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders collapsible cards 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -1944,7 +1936,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -2447,15 +2439,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download full report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download full report (CSV)
             </button>
           </div>
         </div>
@@ -2485,12 +2475,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders full report 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -2519,7 +2509,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -3022,15 +3012,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download full report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download full report (CSV)
             </button>
           </div>
         </div>
@@ -3060,12 +3048,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders inactive learners past month 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -3094,7 +3082,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -3619,15 +3607,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download current report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download current report (CSV)
             </button>
           </div>
         </div>
@@ -3657,12 +3643,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders inactive learners past week 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -3691,7 +3677,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -4216,15 +4202,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download current report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download current report (CSV)
             </button>
           </div>
         </div>
@@ -4254,12 +4238,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders learners not enrolled in an active course 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -4288,7 +4272,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -4811,15 +4795,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download current report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download current report (CSV)
             </button>
           </div>
         </div>
@@ -4849,12 +4831,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders registered but not enrolled report 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -4883,7 +4865,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -5403,15 +5385,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download current report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download current report (CSV)
             </button>
           </div>
         </div>
@@ -5441,12 +5421,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with dashboard analytics data renders top active learners 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -5475,7 +5455,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -6000,15 +5980,13 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
               type="button"
             >
               <span>
-                <span>
-                  <span
-                    aria-hidden={true}
-                    className="fa mr-2 fa-download"
-                    id="Icon1"
-                  />
-                </span>
-                Download current report (CSV)
+                <span
+                  aria-hidden={true}
+                  className="fa mr-2 fa-download"
+                  id="Icon1"
+                />
               </span>
+              Download current report (CSV)
             </button>
           </div>
         </div>
@@ -6038,12 +6016,12 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with error state 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -6072,7 +6050,7 @@ exports[`<Admin /> renders correctly with error state 1`] = `
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -6125,9 +6103,7 @@ exports[`<Admin /> renders correctly with error state 1`] = `
                 >
                   Unable to load overview
                 </span>
-                <span>
-                  Try refreshing your screen (Network Error)
-                </span>
+                Try refreshing your screen (Network Error)
               </div>
             </div>
           </div>
@@ -6179,12 +6155,12 @@ exports[`<Admin /> renders correctly with error state 1`] = `
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<Admin /> renders correctly with loading state 1`] = `
-<div>
+Array [
   <div
     className="hero py-4 pt-md-5 pb-md-0"
   >
@@ -6213,7 +6189,7 @@ exports[`<Admin /> renders correctly with loading state 1`] = `
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className="container"
   >
@@ -6290,6 +6266,6 @@ exports[`<Admin /> renders correctly with loading state 1`] = `
         </p>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -234,7 +234,7 @@ class Admin extends React.Component {
     const csvErrorMessage = this.getCsvErrorMessage(tableMetadata.csvButtonId);
 
     return (
-      <div>
+      <React.Fragment>
         <Helmet>
           <title>Learner and Progress Report</title>
         </Helmet>
@@ -297,7 +297,7 @@ class Admin extends React.Component {
             </div>
           </div>
         </div>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/CompletedLearnersTable/__snapshots__/CompletedLearnersTable.test.jsx.snap
+++ b/src/components/CompletedLearnersTable/__snapshots__/CompletedLearnersTable.test.jsx.snap
@@ -27,9 +27,7 @@ exports[`CompletedLearnersTable renders empty state correctly 1`] = `
         <div
           className="message"
         >
-          <span>
-            There are no results.
-          </span>
+          There are no results.
         </div>
       </div>
     </div>

--- a/src/components/DownloadCsvButton/index.jsx
+++ b/src/components/DownloadCsvButton/index.jsx
@@ -21,10 +21,10 @@ class DownloadCsvButton extends React.Component {
         className={['btn-outline-primary', 'download-btn']}
         disabled={disabled || csvLoading}
         label={
-          <span>
+          <React.Fragment>
             <Icon className={['fa', 'mr-2'].concat(downloadButtonIconClasses)} />
             {buttonLabel}
-          </span>
+          </React.Fragment>
         }
         onClick={() => fetchCsv(fetchMethod)}
       />

--- a/src/components/EnrolledLearnersForInactiveCoursesTable/__snapshots__/EnrolledLearnersForInactiveCoursesTable.test.jsx.snap
+++ b/src/components/EnrolledLearnersForInactiveCoursesTable/__snapshots__/EnrolledLearnersForInactiveCoursesTable.test.jsx.snap
@@ -27,9 +27,7 @@ exports[`EnrolledLearnersForInactiveCoursesTable renders empty state correctly 1
         <div
           className="message"
         >
-          <span>
-            There are no results.
-          </span>
+          There are no results.
         </div>
       </div>
     </div>

--- a/src/components/EnrolledLearnersTable/__snapshots__/EnrolledLearnersTable.test.jsx.snap
+++ b/src/components/EnrolledLearnersTable/__snapshots__/EnrolledLearnersTable.test.jsx.snap
@@ -27,9 +27,7 @@ exports[`EnrolledLearnersTable renders empty state correctly 1`] = `
         <div
           className="message"
         >
-          <span>
-            There are no results.
-          </span>
+          There are no results.
         </div>
       </div>
     </div>

--- a/src/components/EnrollmentsTable/__snapshots__/EnrollmentsTable.test.jsx.snap
+++ b/src/components/EnrollmentsTable/__snapshots__/EnrollmentsTable.test.jsx.snap
@@ -27,9 +27,7 @@ exports[`EnrollmentsTable renders empty state correctly 1`] = `
         <div
           className="message"
         >
-          <span>
-            There are no results.
-          </span>
+          There are no results.
         </div>
       </div>
     </div>

--- a/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
+++ b/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
@@ -1,676 +1,664 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<EnterpriseList /> renders correctly call clearPortalConfiguration and getLocalUser props 1`] = `
-<div>
+<div
+  className="container"
+>
   <div
-    className="container"
+    className="row mt-4"
   >
     <div
-      className="row mt-4"
+      className="col-sm-12 col-md"
+    >
+      <h1
+        className={null}
+      >
+        Enterprise List
+      </h1>
+    </div>
+    <div
+      className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
     >
       <div
-        className="col-sm-12 col-md"
-      >
-        <h1
-          className={null}
-        >
-          Enterprise List
-        </h1>
-      </div>
-      <div
-        className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
+        className="border search-field"
+        onBlur={[Function]}
+        onFocus={[Function]}
       >
         <div
-          className="border search-field"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="form-group form-inline"
         >
-          <div
-            className="form-group form-inline"
+          <label
+            className=""
+            htmlFor="asInput2"
+            id="label-asInput2"
           >
-            <label
-              className=""
-              htmlFor="asInput2"
-              id="label-asInput2"
-            >
-              Search:
-            </label>
+            Search:
+          </label>
+          <div
+            className="input-group"
+          >
             <div
-              className="input-group"
+              className="input-group-prepend"
+            />
+            <input
+              aria-describedby="error-asInput2"
+              aria-invalid={false}
+              autoComplete="off"
+              className="form-control is-invalid-nodanger input no-clear-btn"
+              disabled={false}
+              id="asInput2"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onKeyPress={[Function]}
+              placeholder=""
+              readOnly={false}
+              required={false}
+              themes={Array []}
+              type="search"
+              value=""
+            />
+            <div
+              className="input-group-append"
             >
-              <div
-                className="input-group-prepend"
-              />
-              <input
-                aria-describedby="error-asInput2"
-                aria-invalid={false}
-                autoComplete="off"
-                className="form-control is-invalid-nodanger input no-clear-btn"
-                disabled={false}
-                id="asInput2"
-                name="search"
+              <button
+                className="btn search-btn"
+                disabled={true}
                 onBlur={[Function]}
-                onChange={[Function]}
-                onKeyPress={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                themes={Array []}
-                type="search"
-                value=""
-              />
-              <div
-                className="input-group-append"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
-                <button
-                  className="btn search-btn"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <span>
-                    <span
-                      aria-hidden={true}
-                      className="fa fa-search"
-                      id="Icon1"
-                    />
-                    <span
-                      className="sr-only"
-                    >
-                      Submit search
-                    </span>
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon1"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
                   </span>
-                </button>
-              </div>
+                </span>
+              </button>
             </div>
-            <div
-              aria-live="polite"
-              className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput2"
-            >
-              <span />
-            </div>
+          </div>
+          <div
+            aria-live="polite"
+            className="invalid-feedback invalid-feedback-nodanger"
+            id="error-asInput2"
+          >
+            <span />
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col"
     >
-      <div
-        className="col"
-      >
-        <div />
-      </div>
+      <div />
     </div>
   </div>
 </div>
 `;
 
 exports[`<EnterpriseList /> renders correctly with empty enterprises data 1`] = `
-<div>
+<div
+  className="container"
+>
   <div
-    className="container"
+    className="row mt-4"
   >
     <div
-      className="row mt-4"
+      className="col-sm-12 col-md"
+    >
+      <h1
+        className={null}
+      >
+        Enterprise List
+      </h1>
+    </div>
+    <div
+      className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
     >
       <div
-        className="col-sm-12 col-md"
-      >
-        <h1
-          className={null}
-        >
-          Enterprise List
-        </h1>
-      </div>
-      <div
-        className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
+        className="border search-field"
+        onBlur={[Function]}
+        onFocus={[Function]}
       >
         <div
-          className="border search-field"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="form-group form-inline"
         >
-          <div
-            className="form-group form-inline"
+          <label
+            className=""
+            htmlFor="asInput4"
+            id="label-asInput4"
           >
-            <label
-              className=""
-              htmlFor="asInput4"
-              id="label-asInput4"
-            >
-              Search:
-            </label>
+            Search:
+          </label>
+          <div
+            className="input-group"
+          >
             <div
-              className="input-group"
+              className="input-group-prepend"
+            />
+            <input
+              aria-describedby="error-asInput4"
+              aria-invalid={false}
+              autoComplete="off"
+              className="form-control is-invalid-nodanger input no-clear-btn"
+              disabled={false}
+              id="asInput4"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onKeyPress={[Function]}
+              placeholder=""
+              readOnly={false}
+              required={false}
+              themes={Array []}
+              type="search"
+              value=""
+            />
+            <div
+              className="input-group-append"
             >
-              <div
-                className="input-group-prepend"
-              />
-              <input
-                aria-describedby="error-asInput4"
-                aria-invalid={false}
-                autoComplete="off"
-                className="form-control is-invalid-nodanger input no-clear-btn"
-                disabled={false}
-                id="asInput4"
-                name="search"
+              <button
+                className="btn search-btn"
+                disabled={true}
                 onBlur={[Function]}
-                onChange={[Function]}
-                onKeyPress={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                themes={Array []}
-                type="search"
-                value=""
-              />
-              <div
-                className="input-group-append"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
-                <button
-                  className="btn search-btn"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <span>
-                    <span
-                      aria-hidden={true}
-                      className="fa fa-search"
-                      id="Icon1"
-                    />
-                    <span
-                      className="sr-only"
-                    >
-                      Submit search
-                    </span>
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon1"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
                   </span>
-                </button>
-              </div>
+                </span>
+              </button>
             </div>
-            <div
-              aria-live="polite"
-              className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput4"
-            >
-              <span />
-            </div>
+          </div>
+          <div
+            aria-live="polite"
+            className="invalid-feedback invalid-feedback-nodanger"
+            id="error-asInput4"
+          >
+            <span />
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col"
     >
-      <div
-        className="col"
-      >
-        <div />
-      </div>
+      <div />
     </div>
   </div>
 </div>
 `;
 
 exports[`<EnterpriseList /> renders correctly with enterprises data 1`] = `
-<div>
+<div
+  className="container"
+>
   <div
-    className="container"
+    className="row mt-4"
   >
     <div
-      className="row mt-4"
+      className="col-sm-12 col-md"
+    >
+      <h1
+        className={null}
+      >
+        Enterprise List
+      </h1>
+    </div>
+    <div
+      className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
     >
       <div
-        className="col-sm-12 col-md"
-      >
-        <h1
-          className={null}
-        >
-          Enterprise List
-        </h1>
-      </div>
-      <div
-        className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
+        className="border search-field"
+        onBlur={[Function]}
+        onFocus={[Function]}
       >
         <div
-          className="border search-field"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="form-group form-inline"
         >
-          <div
-            className="form-group form-inline"
+          <label
+            className=""
+            htmlFor="asInput3"
+            id="label-asInput3"
           >
-            <label
-              className=""
-              htmlFor="asInput3"
-              id="label-asInput3"
-            >
-              Search:
-            </label>
+            Search:
+          </label>
+          <div
+            className="input-group"
+          >
             <div
-              className="input-group"
+              className="input-group-prepend"
+            />
+            <input
+              aria-describedby="error-asInput3"
+              aria-invalid={false}
+              autoComplete="off"
+              className="form-control is-invalid-nodanger input no-clear-btn"
+              disabled={false}
+              id="asInput3"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onKeyPress={[Function]}
+              placeholder=""
+              readOnly={false}
+              required={false}
+              themes={Array []}
+              type="search"
+              value=""
+            />
+            <div
+              className="input-group-append"
             >
-              <div
-                className="input-group-prepend"
-              />
-              <input
-                aria-describedby="error-asInput3"
-                aria-invalid={false}
-                autoComplete="off"
-                className="form-control is-invalid-nodanger input no-clear-btn"
-                disabled={false}
-                id="asInput3"
-                name="search"
+              <button
+                className="btn search-btn"
+                disabled={true}
                 onBlur={[Function]}
-                onChange={[Function]}
-                onKeyPress={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                themes={Array []}
-                type="search"
-                value=""
-              />
-              <div
-                className="input-group-append"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
-                <button
-                  className="btn search-btn"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <span>
-                    <span
-                      aria-hidden={true}
-                      className="fa fa-search"
-                      id="Icon1"
-                    />
-                    <span
-                      className="sr-only"
-                    >
-                      Submit search
-                    </span>
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon1"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
                   </span>
-                </button>
-              </div>
+                </span>
+              </button>
             </div>
-            <div
-              aria-live="polite"
-              className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput3"
-            >
-              <span />
-            </div>
+          </div>
+          <div
+            aria-live="polite"
+            className="invalid-feedback invalid-feedback-nodanger"
+            id="error-asInput3"
+          >
+            <span />
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col"
     >
-      <div
-        className="col"
-      >
-        <div />
-      </div>
+      <div />
     </div>
   </div>
 </div>
 `;
 
 exports[`<EnterpriseList /> renders correctly with error state 1`] = `
-<div>
+<div
+  className="container"
+>
   <div
-    className="container"
+    className="row mt-4"
   >
     <div
-      className="row mt-4"
+      className="col-sm-12 col-md"
+    >
+      <h1
+        className={null}
+      >
+        Enterprise List
+      </h1>
+    </div>
+    <div
+      className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
     >
       <div
-        className="col-sm-12 col-md"
-      >
-        <h1
-          className={null}
-        >
-          Enterprise List
-        </h1>
-      </div>
-      <div
-        className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
+        className="border search-field"
+        onBlur={[Function]}
+        onFocus={[Function]}
       >
         <div
-          className="border search-field"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="form-group form-inline"
         >
-          <div
-            className="form-group form-inline"
+          <label
+            className=""
+            htmlFor="asInput7"
+            id="label-asInput7"
           >
-            <label
-              className=""
-              htmlFor="asInput7"
-              id="label-asInput7"
-            >
-              Search:
-            </label>
+            Search:
+          </label>
+          <div
+            className="input-group"
+          >
             <div
-              className="input-group"
+              className="input-group-prepend"
+            />
+            <input
+              aria-describedby="error-asInput7"
+              aria-invalid={false}
+              autoComplete="off"
+              className="form-control is-invalid-nodanger input no-clear-btn"
+              disabled={false}
+              id="asInput7"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onKeyPress={[Function]}
+              placeholder=""
+              readOnly={false}
+              required={false}
+              themes={Array []}
+              type="search"
+              value=""
+            />
+            <div
+              className="input-group-append"
             >
-              <div
-                className="input-group-prepend"
-              />
-              <input
-                aria-describedby="error-asInput7"
-                aria-invalid={false}
-                autoComplete="off"
-                className="form-control is-invalid-nodanger input no-clear-btn"
-                disabled={false}
-                id="asInput7"
-                name="search"
+              <button
+                className="btn search-btn"
+                disabled={true}
                 onBlur={[Function]}
-                onChange={[Function]}
-                onKeyPress={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                themes={Array []}
-                type="search"
-                value=""
-              />
-              <div
-                className="input-group-append"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
-                <button
-                  className="btn search-btn"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <span>
-                    <span
-                      aria-hidden={true}
-                      className="fa fa-search"
-                      id="Icon1"
-                    />
-                    <span
-                      className="sr-only"
-                    >
-                      Submit search
-                    </span>
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon1"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
                   </span>
-                </button>
-              </div>
+                </span>
+              </button>
             </div>
-            <div
-              aria-live="polite"
-              className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput7"
-            >
-              <span />
-            </div>
+          </div>
+          <div
+            aria-live="polite"
+            className="invalid-feedback invalid-feedback-nodanger"
+            id="error-asInput7"
+          >
+            <span />
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col"
     >
-      <div
-        className="col"
-      >
-        <div />
-      </div>
+      <div />
     </div>
   </div>
 </div>
 `;
 
 exports[`<EnterpriseList /> renders correctly with loading state 1`] = `
-<div>
+<div
+  className="container"
+>
   <div
-    className="container"
+    className="row mt-4"
   >
     <div
-      className="row mt-4"
+      className="col-sm-12 col-md"
+    >
+      <h1
+        className={null}
+      >
+        Enterprise List
+      </h1>
+    </div>
+    <div
+      className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
     >
       <div
-        className="col-sm-12 col-md"
-      >
-        <h1
-          className={null}
-        >
-          Enterprise List
-        </h1>
-      </div>
-      <div
-        className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
+        className="border search-field"
+        onBlur={[Function]}
+        onFocus={[Function]}
       >
         <div
-          className="border search-field"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="form-group form-inline"
         >
-          <div
-            className="form-group form-inline"
+          <label
+            className=""
+            htmlFor="asInput8"
+            id="label-asInput8"
           >
-            <label
-              className=""
-              htmlFor="asInput8"
-              id="label-asInput8"
-            >
-              Search:
-            </label>
+            Search:
+          </label>
+          <div
+            className="input-group"
+          >
             <div
-              className="input-group"
+              className="input-group-prepend"
+            />
+            <input
+              aria-describedby="error-asInput8"
+              aria-invalid={false}
+              autoComplete="off"
+              className="form-control is-invalid-nodanger input no-clear-btn"
+              disabled={false}
+              id="asInput8"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onKeyPress={[Function]}
+              placeholder=""
+              readOnly={false}
+              required={false}
+              themes={Array []}
+              type="search"
+              value=""
+            />
+            <div
+              className="input-group-append"
             >
-              <div
-                className="input-group-prepend"
-              />
-              <input
-                aria-describedby="error-asInput8"
-                aria-invalid={false}
-                autoComplete="off"
-                className="form-control is-invalid-nodanger input no-clear-btn"
-                disabled={false}
-                id="asInput8"
-                name="search"
+              <button
+                className="btn search-btn"
+                disabled={true}
                 onBlur={[Function]}
-                onChange={[Function]}
-                onKeyPress={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                themes={Array []}
-                type="search"
-                value=""
-              />
-              <div
-                className="input-group-append"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
-                <button
-                  className="btn search-btn"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <span>
-                    <span
-                      aria-hidden={true}
-                      className="fa fa-search"
-                      id="Icon1"
-                    />
-                    <span
-                      className="sr-only"
-                    >
-                      Submit search
-                    </span>
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon1"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
                   </span>
-                </button>
-              </div>
+                </span>
+              </button>
             </div>
-            <div
-              aria-live="polite"
-              className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput8"
-            >
-              <span />
-            </div>
+          </div>
+          <div
+            aria-live="polite"
+            className="invalid-feedback invalid-feedback-nodanger"
+            id="error-asInput8"
+          >
+            <span />
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col"
     >
-      <div
-        className="col"
-      >
-        <div />
-      </div>
+      <div />
     </div>
   </div>
 </div>
 `;
 
 exports[`<EnterpriseList /> renders correctly with search query and empty enterprises data 1`] = `
-<div>
+<div
+  className="container"
+>
   <div
-    className="container"
+    className="row mt-4"
   >
     <div
-      className="row mt-4"
+      className="col-sm-12 col-md"
+    >
+      <h1
+        className={null}
+      >
+        Enterprise List
+      </h1>
+    </div>
+    <div
+      className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
     >
       <div
-        className="col-sm-12 col-md"
-      >
-        <h1
-          className={null}
-        >
-          Enterprise List
-        </h1>
-      </div>
-      <div
-        className="col-sm-12 col-md-6 col-lg-4 mb-3 mb-md-0"
+        className="border search-field"
+        onBlur={[Function]}
+        onFocus={[Function]}
       >
         <div
-          className="border search-field"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="form-group form-inline"
         >
-          <div
-            className="form-group form-inline"
+          <label
+            className=""
+            htmlFor="asInput6"
+            id="label-asInput6"
           >
-            <label
-              className=""
-              htmlFor="asInput6"
-              id="label-asInput6"
-            >
-              Search:
-            </label>
+            Search:
+          </label>
+          <div
+            className="input-group"
+          >
             <div
-              className="input-group"
+              className="input-group-prepend"
+            />
+            <input
+              aria-describedby="error-asInput6"
+              aria-invalid={false}
+              autoComplete="off"
+              className="form-control is-invalid-nodanger input"
+              disabled={false}
+              id="asInput6"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onKeyPress={[Function]}
+              placeholder=""
+              readOnly={false}
+              required={false}
+              themes={Array []}
+              type="search"
+              value="enterprise name"
+            />
+            <div
+              className="input-group-append"
             >
-              <div
-                className="input-group-prepend"
-              />
-              <input
-                aria-describedby="error-asInput6"
-                aria-invalid={false}
-                autoComplete="off"
-                className="form-control is-invalid-nodanger input"
-                disabled={false}
-                id="asInput6"
-                name="search"
+              <button
+                className="btn clear-btn ml-1"
                 onBlur={[Function]}
-                onChange={[Function]}
-                onKeyPress={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                themes={Array []}
-                type="search"
-                value="enterprise name"
-              />
-              <div
-                className="input-group-append"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
               >
-                <button
-                  className="btn clear-btn ml-1"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <small>
-                    <span>
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-times"
-                        id="icon-SearchField5"
-                      />
-                      <span
-                        className="sr-only"
-                      >
-                        Clear search
-                      </span>
-                    </span>
-                  </small>
-                </button>
-                <button
-                  className="btn search-btn border-left"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
+                <small>
                   <span>
                     <span
                       aria-hidden={true}
-                      className="fa fa-search"
-                      id="Icon1"
+                      className="fa fa-times"
+                      id="icon-SearchField5"
                     />
                     <span
                       className="sr-only"
                     >
-                      Submit search
+                      Clear search
                     </span>
                   </span>
-                </button>
-              </div>
+                </small>
+              </button>
+              <button
+                className="btn search-btn border-left"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon1"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
+                  </span>
+                </span>
+              </button>
             </div>
-            <div
-              aria-live="polite"
-              className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput6"
-            >
-              <span />
-            </div>
+          </div>
+          <div
+            aria-live="polite"
+            className="invalid-feedback invalid-feedback-nodanger"
+            id="error-asInput6"
+          >
+            <span />
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col"
     >
-      <div
-        className="col"
-      >
-        <div />
-      </div>
+      <div />
     </div>
   </div>
 </div>

--- a/src/components/EnterpriseList/index.jsx
+++ b/src/components/EnterpriseList/index.jsx
@@ -97,7 +97,7 @@ class EnterpriseList extends React.Component {
     const { searchQuery } = this.state;
 
     return (
-      <div>
+      <React.Fragment>
         <Helmet>
           <title>Enterprise List</title>
         </Helmet>
@@ -133,7 +133,7 @@ class EnterpriseList extends React.Component {
             </div>
           </div>
         </div>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/LearnerActivityTable/__snapshots__/LearnerActivityTable.test.jsx.snap
+++ b/src/components/LearnerActivityTable/__snapshots__/LearnerActivityTable.test.jsx.snap
@@ -443,9 +443,7 @@ exports[`LearnerActivityTable renders empty state correctly 1`] = `
         <div
           className="message"
         >
-          <span>
-            There are no results.
-          </span>
+          There are no results.
         </div>
       </div>
     </div>

--- a/src/components/RegisteredLearnersTable/__snapshots__/RegisteredLearnersTable.test.jsx.snap
+++ b/src/components/RegisteredLearnersTable/__snapshots__/RegisteredLearnersTable.test.jsx.snap
@@ -27,9 +27,7 @@ exports[`RegisteredLearnersTable renders empty state correctly 1`] = `
         <div
           className="message"
         >
-          <span>
-            There are no results.
-          </span>
+          There are no results.
         </div>
       </div>
     </div>

--- a/src/components/StatusAlert/index.jsx
+++ b/src/components/StatusAlert/index.jsx
@@ -34,7 +34,7 @@ const StatusAlert = (props) => {
             {title &&
               <span className="title">{title}</span>
             }
-            <span>{message}</span>
+            {message}
           </div>
         </div>
       }

--- a/src/components/TableLoadingOverlay/index.jsx
+++ b/src/components/TableLoadingOverlay/index.jsx
@@ -4,12 +4,12 @@ import LoadingMessage from '../LoadingMessage';
 import './TableLoadingOverlay.scss';
 
 const TableLoadingOverlay = () => (
-  <div>
+  <React.Fragment>
     <div className="table-loading-overlay" />
     <div className="table-loading-message d-flex align-items-center justify-content-center ">
       <LoadingMessage className="loading" />
     </div>
-  </div>
+  </React.Fragment>
 );
 
 export default TableLoadingOverlay;

--- a/src/containers/EnterpriseApp/__snapshots__/EnterpriseApp.test.jsx.snap
+++ b/src/containers/EnterpriseApp/__snapshots__/EnterpriseApp.test.jsx.snap
@@ -1,27 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EnterpriseApp renders not found page correctly 1`] = `
-<div>
+<div
+  className="container mt-3"
+>
   <div
-    className="container mt-3"
+    className="text-center py-5"
   >
-    <div
-      className="text-center py-5"
+    <h1
+      className={null}
     >
-      <h1
-        className={null}
-      >
-        404
-      </h1>
-      <p
-        className="lead"
-      >
-        Oops, sorry we can't find that page!
-      </p>
-      <p>
-        Either something went wrong or the page doesn't exist anymore.
-      </p>
-    </div>
+      404
+    </h1>
+    <p
+      className="lead"
+    >
+      Oops, sorry we can't find that page!
+    </p>
+    <p>
+      Either something went wrong or the page doesn't exist anymore.
+    </p>
   </div>
 </div>
 `;

--- a/src/containers/EnterpriseApp/index.jsx
+++ b/src/containers/EnterpriseApp/index.jsx
@@ -36,7 +36,7 @@ class EnterpriseApp extends React.Component {
     }
 
     return (
-      <div>
+      <React.Fragment>
         <Switch>
           <Redirect
             exact
@@ -52,7 +52,7 @@ class EnterpriseApp extends React.Component {
           <Route exact path={`${baseUrl}/support`} component={SupportPage} />
           <Route path="" component={NotFoundPage} />
         </Switch>
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -72,9 +72,8 @@ EnterpriseApp.defaultProps = {
   error: null,
 };
 
-const tableId = 'enterprise-list';
 const mapStateToProps = (state) => {
-  const enterpriseListState = state.table[tableId] || {};
+  const enterpriseListState = state.table['enterprise-list'] || {};
 
   return {
     enterprises: enterpriseListState.data,

--- a/src/containers/EnterpriseIndexPage/index.jsx
+++ b/src/containers/EnterpriseIndexPage/index.jsx
@@ -4,10 +4,8 @@ import { clearPortalConfiguration } from '../../data/actions/portalConfiguration
 import { getLocalUser } from '../../data/actions/authentication';
 import searchEnterpriseList from '../../data/actions/enterpriseList';
 
-const tableId = 'enterprise-list';
 const mapStateToProps = (state) => {
-  const tableState = state.table[tableId] || {};
-
+  const tableState = state.table['enterprise-list'] || {};
   return {
     enterpriseList: tableState.data,
     loading: tableState.loading,

--- a/src/containers/ErrorPage/__snapshots__/ErrorPage.test.jsx.snap
+++ b/src/containers/ErrorPage/__snapshots__/ErrorPage.test.jsx.snap
@@ -4,36 +4,32 @@ exports[`<ErrorPage /> renders correctly 1`] = `
 <div
   className="container"
 >
-  <div>
+  <div
+    className="row mt-4"
+  >
     <div
-      className="row mt-4"
+      className="col"
     >
-      <div
-        className="col"
+      <h1
+        className={null}
       >
-        <h1
-          className={null}
-        >
-          Error
-        </h1>
+        Error
+      </h1>
+      <div
+        className="alert fade alert-danger show"
+        hidden={false}
+        role="alert"
+      >
         <div
-          className="alert fade alert-danger show"
-          hidden={false}
-          role="alert"
+          className="alert-dialog"
         >
           <div
-            className="alert-dialog"
+            className=""
           >
             <div
-              className=""
+              className="message"
             >
-              <div
-                className="message"
-              >
-                <span>
-                  Something went terribly wrong
-                </span>
-              </div>
+              Something went terribly wrong
             </div>
           </div>
         </div>

--- a/src/containers/ErrorPage/index.jsx
+++ b/src/containers/ErrorPage/index.jsx
@@ -14,7 +14,7 @@ const ErrorPage = (props) => {
       {props.status === 404 ? (
         <NotFoundPage />
       ) : (
-        <div>
+        <React.Fragment>
           <Helmet>
             <title>Error</title>
           </Helmet>
@@ -27,7 +27,7 @@ const ErrorPage = (props) => {
               />
             </div>
           </div>
-        </div>
+        </React.Fragment>
       )}
     </div>
   );

--- a/src/containers/LogoutHandler/index.jsx
+++ b/src/containers/LogoutHandler/index.jsx
@@ -16,7 +16,7 @@ class LogoutHandler extends React.Component {
   }
 
   render() {
-    return (<Redirect to="/login" />);
+    return <Redirect to="/login" />;
   }
 }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -25,7 +25,7 @@ import './index.scss';
 const AppWrapper = () => (
   <Provider store={store}>
     <ConnectedRouter history={history}>
-      <div>
+      <React.Fragment>
         <Helmet
           titleTemplate="%s - edX Portal"
           defaultTitle="edX Portal"
@@ -41,7 +41,7 @@ const AppWrapper = () => (
           <Route component={NotFoundPage} />
         </Switch>
         <Footer />
-      </div>
+      </React.Fragment>
     </ConnectedRouter>
   </Provider>
 );


### PR DESCRIPTION
In React, DOM/JSX elements must be nested under a single parent node. This usually leads to having unnecessary elements rendered to the DOM. For example, our `DownloadCsvButton` renders text next to an icon, so we need to wrap both the icon and the text in a `<span>`, e.g.

```jsx
<span>
  <Icon {...props} />
  This is an awesome button.
</span>
```

However, this results in rendering an unnecessary `<span>` in the DOM. Instead, we could use [`React.Fragment`](https://reactjs.org/docs/fragments.html) which allows you to group elements without rendering any unneeded elements to the DOM.

This PR goes through our components/containers to identify where using `React.Fragment` makes sense. FYI, because this changes the underlying structure of our DOM (i.e., removing elements), there are a fair amount of snapshot changes.