### PR TITLE
Rename iconClassName to iconClassNames in StatusAlert

### DIFF
--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -181,7 +181,7 @@ class Admin extends React.Component {
       <StatusAlert
         className={['mt-3']}
         alertType="danger"
-        iconClassName={['fa', 'fa-times-circle']}
+        iconClassNames={['fa', 'fa-times-circle']}
         title="Unable to load overview"
         message={`Try refreshing your screen (${this.props.error.message})`}
       />
@@ -193,7 +193,7 @@ class Admin extends React.Component {
       <StatusAlert
         className={['mt-3']}
         alertType="danger"
-        iconClassName={['fa', 'fa-times-circle']}
+        iconClassNames={['fa', 'fa-times-circle']}
         title="Unable to Generate CSV Report"
         message={`Please try again. (${message})`}
       />

--- a/src/components/StatusAlert/index.jsx
+++ b/src/components/StatusAlert/index.jsx
@@ -9,7 +9,7 @@ const StatusAlert = (props) => {
   const {
     alertType,
     className,
-    iconClassName,
+    iconClassNames,
     title,
     message,
   } = props;
@@ -22,12 +22,12 @@ const StatusAlert = (props) => {
       dialog={
         <div className={
           classNames({
-            'd-flex': iconClassName && iconClassName.length > 0,
+            'd-flex': iconClassNames.length > 0,
           })}
         >
-          {iconClassName && iconClassName.length > 0 &&
+          {iconClassNames.length > 0 &&
             <div className="icon mr-2">
-              <Icon className={iconClassName} />
+              <Icon className={iconClassNames} />
             </div>
           }
           <div className="message">
@@ -47,13 +47,13 @@ StatusAlert.propTypes = {
   alertType: PropTypes.string.isRequired,
   message: PropTypes.string.isRequired,
   className: PropTypes.arrayOf(PropTypes.string),
-  iconClassName: PropTypes.arrayOf(PropTypes.string),
+  iconClassNames: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string,
 };
 
 StatusAlert.defaultProps = {
   className: [],
-  iconClassName: null,
+  iconClassNames: [],
   title: null,
 };
 

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -112,7 +112,7 @@ class TableComponent extends React.Component {
     return (
       <StatusAlert
         alertType="danger"
-        iconClassName={['fa', 'fa-times-circle']}
+        iconClassNames={['fa', 'fa-times-circle']}
         title="Unable to load data"
         message={`Try refreshing your screen (${this.props.error.message})`}
       />
@@ -123,7 +123,7 @@ class TableComponent extends React.Component {
     return (
       <StatusAlert
         alertType="warning"
-        iconClassName={['fa', 'fa-exclamation-circle']}
+        iconClassNames={['fa', 'fa-exclamation-circle']}
         message="There are no results."
       />
     );


### PR DESCRIPTION
The prop `iconClassName` is misleading as it should be an array of strings, not a single string. In this PR, I recommend renaming `iconClassName` to `iconClassNames` as well as simplifying the logic by defaulting this prop to an empty array.