### PR TITLE
Fix EnvironmentPlugin warnings during production builds

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -105,7 +105,7 @@ module.exports = Merge.smart(commonConfig, {
       LMS_BASE_URL: 'http://localhost:18000',
       DATA_API_BASE_URL: 'http://localhost:8000',
       LMS_CLIENT_ID: 'CMehRRNqfiBRVJKnPOkjBDjAvurtnHpELoehKAvZ',
-      SEGMENT_KEY: '',
+      SEGMENT_KEY: null,
       FEATURE_FLAGS: {},
     }),
   ],

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -138,12 +138,12 @@ module.exports = Merge.smart(commonConfig, {
     new webpack.EnvironmentPlugin({
       // default values of undefined to force definition in the environment at build time
       NODE_ENV: 'production',
-      LMS_BASE_URL: undefined,
-      DATA_API_BASE_URL: undefined,
-      LMS_CLIENT_ID: undefined,
-      SEGMENT_KEY: undefined,
-      NEW_RELIC_APP_ID: undefined,
-      NEW_RELIC_LICENSE_KEY: undefined,
+      LMS_BASE_URL: null,
+      DATA_API_BASE_URL: null,
+      LMS_CLIENT_ID: null,
+      SEGMENT_KEY: null,
+      NEW_RELIC_APP_ID: null,
+      NEW_RELIC_LICENSE_KEY: null,
       FEATURE_FLAGS: {},
     }),
     new HtmlWebpackNewRelicPlugin({


### PR DESCRIPTION
Currently, when running `npm run build` emits several warnings about `EnvironmentPlugin` environment variables being undefined:

![image](https://user-images.githubusercontent.com/2828721/47767689-1a167d80-dcab-11e8-990f-341b04c6bd56.png)

This PR fixes these warnings by setting the default values of the environment variables to `null` instead of `undefined`.