### PR TITLE
Fix import paths to remove src

### DIFF
--- a/src/demo/rewireEnterpriseDataApiService.js
+++ b/src/demo/rewireEnterpriseDataApiService.js
@@ -1,4 +1,4 @@
-import EnterpriseDataApiService from '../../src/data/services/EnterpriseDataApiService';
+import EnterpriseDataApiService from '../data/services/EnterpriseDataApiService';
 import {
   filterCompletedLearnerCourses,
   filteredEnrollments,

--- a/src/demo/rewireEnterpriseDataApiService.test.js
+++ b/src/demo/rewireEnterpriseDataApiService.test.js
@@ -1,4 +1,4 @@
-import EnterpriseDataApiService from '../../src/data/services/EnterpriseDataApiService';
+import EnterpriseDataApiService from '../data/services/EnterpriseDataApiService';
 import rewire from './rewireEnterpriseDataApiService';
 
 describe('rewireEnterpriseDataApiService', () => {


### PR DESCRIPTION
We have 2 imports that are going up beyond the `src` direction, when it is not needed to get to the relevant files.