### PR TITLE
Add buttonType prop to NumberCard details button

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -227,7 +227,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -319,7 +319,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -427,7 +427,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -551,7 +551,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -817,7 +817,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -909,7 +909,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -1017,7 +1017,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -1141,7 +1141,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -1407,7 +1407,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -1499,7 +1499,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -1607,7 +1607,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -1731,7 +1731,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -2002,7 +2002,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -2094,7 +2094,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -2202,7 +2202,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -2326,7 +2326,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -2575,7 +2575,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -2667,7 +2667,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -2775,7 +2775,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -2899,7 +2899,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -3148,7 +3148,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -3240,7 +3240,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -3348,7 +3348,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -3472,7 +3472,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -3743,7 +3743,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -3835,7 +3835,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -3943,7 +3943,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -4067,7 +4067,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -4338,7 +4338,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -4430,7 +4430,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -4538,7 +4538,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -4662,7 +4662,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -4931,7 +4931,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -5023,7 +5023,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -5131,7 +5131,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -5255,7 +5255,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -5521,7 +5521,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -5613,7 +5613,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -5721,7 +5721,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -5845,7 +5845,7 @@ Array [
                   className="footer-title"
                 >
                   <button
-                    className="btn toggle-collapse btn-block"
+                    className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}

--- a/src/components/NumberCard/__snapshots__/NumberCard.test.jsx.snap
+++ b/src/components/NumberCard/__snapshots__/NumberCard.test.jsx.snap
@@ -38,7 +38,7 @@ exports[`<NumberCard /> renders correctly with detail actions 1`] = `
       className="footer-title"
     >
       <button
-        className="btn toggle-collapse btn-block"
+        className="btn toggle-collapse btn-block btn-link"
         onBlur={[Function]}
         onClick={[Function]}
         onKeyDown={[Function]}

--- a/src/components/NumberCard/index.jsx
+++ b/src/components/NumberCard/index.jsx
@@ -211,6 +211,7 @@ class NumberCard extends React.Component {
             <div className="footer-title">
               <Button
                 inputRef={(node) => { this.toggleDetailsBtnRef = node; }}
+                buttonType="link"
                 className={['toggle-collapse', 'btn-block']}
                 label={
                   <div className="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
With the refactor of the `NumberCard` expand/collapse button, we're not setting the `buttonType` prop which causes the background to appear gray on Safari and Firefox.

This PR adds `buttonType="link"` to the button which resolves this issue. It also adds a hover/focus state of underline the text in the button which is better for a11y.