### PR TITLE
Add aria-expanded and aria-controls props to collapsible components

### DIFF
--- a/src/components/Admin/AdminCards.jsx
+++ b/src/components/Admin/AdminCards.jsx
@@ -68,6 +68,7 @@ class AdminCards extends React.Component {
         key={cardKey}
       >
         <NumberCard
+          id={cardKey}
           title={title}
           description={card.description}
           iconClassName={card.iconClassName}

--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -223,6 +223,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -251,7 +253,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -311,6 +314,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -339,7 +344,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -415,6 +421,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -443,7 +451,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -535,6 +544,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -563,7 +574,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -793,6 +805,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -821,7 +835,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -881,6 +896,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -909,7 +926,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -985,6 +1003,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -1013,7 +1033,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -1105,6 +1126,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -1133,7 +1156,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -1363,6 +1387,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -1391,7 +1417,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -1451,6 +1478,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -1479,7 +1508,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -1555,6 +1585,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -1583,7 +1615,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -1675,6 +1708,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -1703,7 +1738,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -1938,6 +1974,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -1966,7 +2004,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -2026,6 +2065,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -2054,7 +2095,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -2130,6 +2172,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -2158,7 +2202,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -2250,6 +2295,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -2278,7 +2325,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -2493,6 +2541,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -2521,7 +2571,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -2581,6 +2632,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -2609,7 +2662,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -2685,6 +2739,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -2713,7 +2769,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -2805,6 +2862,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -2833,7 +2892,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -3048,6 +3108,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3076,7 +3138,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -3136,6 +3199,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3164,7 +3229,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -3240,6 +3306,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3268,7 +3336,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -3360,6 +3429,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3388,7 +3459,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -3623,6 +3695,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3651,7 +3725,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -3711,6 +3786,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3739,7 +3816,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -3815,6 +3893,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3843,7 +3923,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -3935,6 +4016,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3963,7 +4046,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -4198,6 +4282,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -4226,7 +4312,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -4286,6 +4373,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -4314,7 +4403,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -4390,6 +4480,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -4418,7 +4510,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -4510,6 +4603,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -4538,7 +4633,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -4771,6 +4867,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -4799,7 +4897,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -4859,6 +4958,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -4887,7 +4988,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -4963,6 +5065,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -4991,7 +5095,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -5083,6 +5188,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5111,7 +5218,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"
@@ -5341,6 +5449,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-numberOfUsers"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5369,7 +5479,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-numberOfUsers"
                 >
                   <a
                     className="btn btn-link"
@@ -5429,6 +5540,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-enrolledLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5457,7 +5570,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-enrolledLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -5533,6 +5647,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-activeLearners"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5561,7 +5677,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-activeLearners"
                 >
                   <a
                     className="btn btn-link"
@@ -5653,6 +5770,8 @@ Array [
                   className="footer-title"
                 >
                   <button
+                    aria-controls="footer-body-courseCompletions"
+                    aria-expanded={false}
                     className="btn toggle-collapse btn-block btn-link"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5681,7 +5800,8 @@ Array [
                   </button>
                 </div>
                 <div
-                  className="footer-body  mt-1 d-none"
+                  className="footer-body mt-1 d-none"
+                  id="footer-body-courseCompletions"
                 >
                   <a
                     className="btn btn-link"

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -116,6 +116,8 @@ class Coupon extends React.Component {
           onKeyDown={this.handleCouponKeyDown}
           role="button"
           tabIndex="0"
+          aria-expanded={detailsExpanded}
+          aria-controls={`coupon-details-${data.id}`}
         >
           <div className="col-sm-12 col-lg-3 mb-2 mb-lg-0">
             <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Coupon Name</small>
@@ -155,7 +157,7 @@ class Coupon extends React.Component {
             {this.renderExpandCollapseIcon()}
           </div>
         </div>
-        {detailsExpanded && <CouponDetails id={data.id} hasError={data.hasError} />}
+        {<CouponDetails id={data.id} expanded={detailsExpanded} hasError={data.hasError} />}
       </div>
     );
   }

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Button, CheckBox, Icon, InputSelect } from '@edx/paragon';
 
 import H3 from '../H3';
@@ -122,94 +123,106 @@ class CouponDetails extends React.Component {
 
   render() {
     const { selectedFilter } = this.state;
-    const { id, hasError } = this.props;
+    const { id, hasError, expanded } = this.props;
 
     return (
-      <div className="coupon-details row no-gutters px-2 my-3">
+      <div
+        id={`coupon-details-${id}`}
+        className={classNames([
+          'coupon-details row no-gutters px-2 my-3',
+          {
+            'd-none': !expanded,
+          },
+        ])}
+      >
         <div className="col">
-          <div className="details-header row no-gutters mb-3">
-            <div className="col-12 col-md-6 mb-2 mb-md-0">
-              <H3>Coupon Details</H3>
-            </div>
-            <div className="col-12 col-md-6 mb-2 mb-md-0 text-md-right">
-              <DownloadCsvButton
-                id="coupon-details"
-                fetchMethod={() => {}}
-                disabled={this.isTableLoading()}
-              />
-            </div>
-          </div>
-          <div className="row mb-3">
-            <div className="filters col-12 col-md-8">
-              <div className="row">
-                <div className="col">
-                  <div className="mb-1">Filter:</div>
-                  <Button
-                    className={['btn-sm', 'mr-2']}
-                    buttonType={selectedFilter === 'not-assigned' ? 'primary' : 'outline-primary'}
-                    label="Not Assigned"
-                    onClick={() => this.setSelectedFilter('not-assigned')}
+          {expanded &&
+            <React.Fragment>
+              <div className="details-header row no-gutters mb-3">
+                <div className="col-12 col-md-6 mb-2 mb-md-0">
+                  <H3>Coupon Details</H3>
+                </div>
+                <div className="col-12 col-md-6 mb-2 mb-md-0 text-md-right">
+                  <DownloadCsvButton
+                    id="coupon-details"
+                    fetchMethod={() => {}}
                     disabled={this.isTableLoading()}
                   />
-                  <Button
-                    className={['btn-sm']}
-                    buttonType={selectedFilter === 'not-redeemed' ? 'primary' : 'outline-primary'}
-                    label="Not Redeemed"
-                    onClick={() => this.setSelectedFilter('not-redeemed')}
-                    disabled={this.isTableLoading()}
-                  />
-                  {selectedFilter &&
-                    <Button
-                      className={['btn-sm', 'ml-2']}
-                      buttonType="outline-secondary"
-                      label={
-                        <React.Fragment>
-                          <Icon className={['fa', 'fa-close', 'mr-1']} />
-                          Clear filters
-                        </React.Fragment>
-                      }
-                      onClick={() => this.setSelectedFilter(null)}
-                    />
-                  }
                 </div>
               </div>
-            </div>
-            <div className="bulk-actions col-12 col-md-4 text-md-right mt-3 m-md-0">
-              <InputSelect
-                className={['mt-1']}
-                name="bulk-action"
-                label="Bulk Action:"
-                value="assign"
-                options={[
-                  { label: 'Assign', value: 'assign' },
-                  { label: 'Remind', value: 'remind' },
-                  { label: 'Revoke', value: 'revoke' },
-                ]}
-                disabled={this.isTableLoading()}
-              />
-              <Button
-                className={['ml-2']}
-                buttonType="primary"
-                label="Go"
-                onClick={() => {}}
-                disabled={this.isTableLoading()}
-              />
-            </div>
-          </div>
-          {this.hasStatusAlert() &&
-            <div className="row mb-3">
-              <div className="col">
-                {hasError && this.renderErrorMessage()}
+              <div className="row mb-3">
+                <div className="filters col-12 col-md-8">
+                  <div className="row">
+                    <div className="col">
+                      <div className="mb-1">Filter:</div>
+                      <Button
+                        className={['btn-sm', 'mr-2']}
+                        buttonType={selectedFilter === 'not-assigned' ? 'primary' : 'outline-primary'}
+                        label="Not Assigned"
+                        onClick={() => this.setSelectedFilter('not-assigned')}
+                        disabled={this.isTableLoading()}
+                      />
+                      <Button
+                        className={['btn-sm']}
+                        buttonType={selectedFilter === 'not-redeemed' ? 'primary' : 'outline-primary'}
+                        label="Not Redeemed"
+                        onClick={() => this.setSelectedFilter('not-redeemed')}
+                        disabled={this.isTableLoading()}
+                      />
+                      {selectedFilter &&
+                        <Button
+                          className={['btn-sm', 'ml-2']}
+                          buttonType="outline-secondary"
+                          label={
+                            <React.Fragment>
+                              <Icon className={['fa', 'fa-close', 'mr-1']} />
+                              Clear filters
+                            </React.Fragment>
+                          }
+                          onClick={() => this.setSelectedFilter(null)}
+                        />
+                      }
+                    </div>
+                  </div>
+                </div>
+                <div className="bulk-actions col-12 col-md-4 text-md-right mt-3 m-md-0">
+                  <InputSelect
+                    className={['mt-1']}
+                    name="bulk-action"
+                    label="Bulk Action:"
+                    value="assign"
+                    options={[
+                      { label: 'Assign', value: 'assign' },
+                      { label: 'Remind', value: 'remind' },
+                      { label: 'Revoke', value: 'revoke' },
+                    ]}
+                    disabled={this.isTableLoading()}
+                  />
+                  <Button
+                    className={['ml-2']}
+                    buttonType="primary"
+                    label="Go"
+                    onClick={() => {}}
+                    disabled={this.isTableLoading()}
+                  />
+                </div>
               </div>
-            </div>
+              {this.hasStatusAlert() &&
+                <div className="row mb-3">
+                  <div className="col">
+                    {hasError && this.renderErrorMessage()}
+                  </div>
+                </div>
+              }
+              <TableContainer
+                id="coupon-details"
+                className="coupon-details-table"
+                fetchMethod={() => EcommerceApiService.fetchCouponDetails(id)}
+                columns={this.tableColumns}
+                formatData={this.formatCouponData}
+              />
+            </React.Fragment>
           }
-          <TableContainer
-            id="coupon-details"
-            className="coupon-details-table"
-            fetchMethod={() => EcommerceApiService.fetchCouponDetails(id)}
-            columns={this.tableColumns}
-            formatData={this.formatCouponData}
-          />
         </div>
       </div>
     );
@@ -217,12 +230,14 @@ class CouponDetails extends React.Component {
 }
 
 CouponDetails.defaultProps = {
+  expanded: false,
   hasError: false,
   couponDetailsTable: {},
 };
 
 CouponDetails.propTypes = {
   id: PropTypes.number.isRequired,
+  expanded: PropTypes.bool,
   hasError: PropTypes.bool,
   couponDetailsTable: PropTypes.shape({}),
 };

--- a/src/components/NumberCard/NumberCard.scss
+++ b/src/components/NumberCard/NumberCard.scss
@@ -61,13 +61,21 @@ $number-card-box-shadow: 0 .125rem .25rem rgba(0,0,0,.075);
             font-weight: 600;
             color: #313131;
             font-size: 0.875rem;
-    
-            &:focus {
-                box-shadow: $input-btn-focus-box-shadow;
-            }
+            text-decoration: none;
 
             .fa {
                 font-size: 1rem;
+            }
+
+            &:hover,
+            &:focus {
+                .details-btn-text {
+                    text-decoration: underline;
+                }
+            }
+
+            &:focus {
+                box-shadow: $input-btn-focus-box-shadow;
             }
         }
     

--- a/src/components/NumberCard/NumberCard.test.jsx
+++ b/src/components/NumberCard/NumberCard.test.jsx
@@ -10,6 +10,7 @@ const getNumberCard = wrapper => wrapper.find('NumberCard');
 const NumberCardWrapper = props => (
   <MemoryRouter>
     <NumberCard
+      id="test-id"
       className="test-class"
       title={10}
       description="This describes the data!"

--- a/src/components/NumberCard/__snapshots__/NumberCard.test.jsx.snap
+++ b/src/components/NumberCard/__snapshots__/NumberCard.test.jsx.snap
@@ -36,6 +36,8 @@ exports[`<NumberCard /> renders correctly with detail actions 1`] = `
       className="footer-title"
     >
       <button
+        aria-controls="footer-body-test-id"
+        aria-expanded={false}
         className="btn toggle-collapse btn-block btn-link"
         onBlur={[Function]}
         onClick={[Function]}
@@ -64,7 +66,8 @@ exports[`<NumberCard /> renders correctly with detail actions 1`] = `
       </button>
     </div>
     <div
-      className="footer-body  mt-1 d-none"
+      className="footer-body mt-1 d-none"
+      id="footer-body-test-id"
     >
       <a
         className="btn btn-link"

--- a/src/components/NumberCard/index.jsx
+++ b/src/components/NumberCard/index.jsx
@@ -174,6 +174,7 @@ class NumberCard extends React.Component {
       iconClassName,
       description,
       detailActions,
+      id,
     } = this.props;
 
     return (
@@ -226,12 +227,15 @@ class NumberCard extends React.Component {
                 }
                 onClick={this.toggleDetails}
                 onKeyDown={this.handleToggleDetailsKeyDown}
+                aria-expanded={detailsExpanded}
+                aria-controls={`footer-body-${id}`}
               />
             </div>
             <div
+              id={`footer-body-${id}`}
               className={classNames(
                 'footer-body',
-                ' mt-1',
+                'mt-1',
                 {
                   'd-none': !detailsExpanded,
                 },
@@ -256,6 +260,7 @@ NumberCard.defaultProps = {
 NumberCard.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   description: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
   className: PropTypes.string,
   iconClassName: PropTypes.string,
   detailActions: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
This PR fixes the a11y of our collapsible components (i.e., `NumberCard`, `Coupon`, `CouponDetails`) by using the `aria-expanded` and `aria-controls` props where relevant.

Note that I needed to refactor the `Coupon` component such that the `CouponDetails` component is always rendered. The reason for this is the `aria-controls` prop in `Coupon` refers to an `id` which must already exist. Before, we would not render the `CouponDetails` until the `Coupon` was expanded so the `id` within `CouponDetails` would not exist, throwing an a11y error. Instead, I am adding the `.d-none` class to hide the `CouponDetails` until the `Coupon` is expanded, ensuring the `id` exists for `aria-controls`.

Also included in this PR is a minor style change to the `NumberCard` details toggle button such that the caret icon does not get underlined on hover/focus.