### PR TITLE
Remove unnecessary DOM wrapper elements

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -101,9 +101,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -632,15 +630,13 @@ Array [
           href="/"
           onClick={[Function]}
         >
-          <span>
-            <span
-              aria-hidden={true}
-              className="fa fa-undo mr-2"
-              id="Icon1"
-            />
-            Reset to 
-            Full Report
-          </span>
+          <span
+            aria-hidden={true}
+            className="fa fa-undo mr-2"
+            id="Icon1"
+          />
+          Reset to 
+          Full Report
         </a>
       </div>
     </div>
@@ -656,10 +652,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -683,9 +677,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -1214,15 +1206,13 @@ Array [
           href="/"
           onClick={[Function]}
         >
-          <span>
-            <span
-              aria-hidden={true}
-              className="fa fa-undo mr-2"
-              id="Icon1"
-            />
-            Reset to 
-            Full Report
-          </span>
+          <span
+            aria-hidden={true}
+            className="fa fa-undo mr-2"
+            id="Icon1"
+          />
+          Reset to 
+          Full Report
         </a>
       </div>
     </div>
@@ -1238,10 +1228,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -1265,9 +1253,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -1796,15 +1782,13 @@ Array [
           href="/"
           onClick={[Function]}
         >
-          <span>
-            <span
-              aria-hidden={true}
-              className="fa fa-undo mr-2"
-              id="Icon1"
-            />
-            Reset to 
-            Full Report
-          </span>
+          <span
+            aria-hidden={true}
+            className="fa fa-undo mr-2"
+            id="Icon1"
+          />
+          Reset to 
+          Full Report
         </a>
         <h3
           className={null}
@@ -1825,10 +1809,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -1852,9 +1834,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -2392,10 +2372,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -2419,9 +2397,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -2959,10 +2935,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -2986,9 +2960,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -3517,15 +3489,13 @@ Array [
           href="/"
           onClick={[Function]}
         >
-          <span>
-            <span
-              aria-hidden={true}
-              className="fa fa-undo mr-2"
-              id="Icon1"
-            />
-            Reset to 
-            Full Report
-          </span>
+          <span
+            aria-hidden={true}
+            className="fa fa-undo mr-2"
+            id="Icon1"
+          />
+          Reset to 
+          Full Report
         </a>
         <h3
           className={null}
@@ -3546,10 +3516,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -3573,9 +3541,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -4104,15 +4070,13 @@ Array [
           href="/"
           onClick={[Function]}
         >
-          <span>
-            <span
-              aria-hidden={true}
-              className="fa fa-undo mr-2"
-              id="Icon1"
-            />
-            Reset to 
-            Full Report
-          </span>
+          <span
+            aria-hidden={true}
+            className="fa fa-undo mr-2"
+            id="Icon1"
+          />
+          Reset to 
+          Full Report
         </a>
         <h3
           className={null}
@@ -4133,10 +4097,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -4160,9 +4122,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -4691,15 +4651,13 @@ Array [
           href="/"
           onClick={[Function]}
         >
-          <span>
-            <span
-              aria-hidden={true}
-              className="fa fa-undo mr-2"
-              id="Icon1"
-            />
-            Reset to 
-            Full Report
-          </span>
+          <span
+            aria-hidden={true}
+            className="fa fa-undo mr-2"
+            id="Icon1"
+          />
+          Reset to 
+          Full Report
         </a>
         <p>
           Learners who have completed all of their courses and/or courses have ended.
@@ -4718,10 +4676,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -4745,9 +4701,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -5276,15 +5230,13 @@ Array [
           href="/"
           onClick={[Function]}
         >
-          <span>
-            <span
-              aria-hidden={true}
-              className="fa fa-undo mr-2"
-              id="Icon1"
-            />
-            Reset to 
-            Full Report
-          </span>
+          <span
+            aria-hidden={true}
+            className="fa fa-undo mr-2"
+            id="Icon1"
+          />
+          Reset to 
+          Full Report
         </a>
       </div>
     </div>
@@ -5300,10 +5252,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -5327,9 +5277,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -5858,15 +5806,13 @@ Array [
           href="/"
           onClick={[Function]}
         >
-          <span>
-            <span
-              aria-hidden={true}
-              className="fa fa-undo mr-2"
-              id="Icon1"
-            />
-            Reset to 
-            Full Report
-          </span>
+          <span
+            aria-hidden={true}
+            className="fa fa-undo mr-2"
+            id="Icon1"
+          />
+          Reset to 
+          Full Report
         </a>
         <h3
           className={null}
@@ -5887,10 +5833,8 @@ Array [
           <div
             className="col-12 col-md-6 pt-1 pb-3"
           >
-            <span>
-              Showing data as of 
-              July 31, 2018
-            </span>
+            Showing data as of 
+            July 31, 2018
           </div>
           <div
             className="col-12 col-md-6 text-md-right"
@@ -5914,9 +5858,7 @@ Array [
         </div>
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -6051,9 +5993,7 @@ Array [
       >
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div
@@ -6133,11 +6073,9 @@ Array [
         className="col"
       >
         <div
-          className="overview mt-3 loading d-flex align-items-center justify-content-center"
+          className="loading d-flex align-items-center justify-content-center overview mt-3"
         >
-          <span>
-            Loading...
-          </span>
+          Loading...
         </div>
       </div>
     </div>
@@ -6162,9 +6100,7 @@ Array [
       >
         <div
           className="mt-3 mb-5"
-        >
-          <div />
-        </div>
+        />
       </div>
     </div>
     <div

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -212,10 +212,8 @@ class Admin extends React.Component {
 
     return (
       <Link to={path} className="reset btn btn-sm btn-outline-primary ml-3">
-        <span>
-          <Icon className={['fa', 'fa-undo', 'mr-2']} />
-          Reset to {this.getMetadataForAction().title}
-        </span>
+        <Icon className={['fa', 'fa-undo', 'mr-2']} />
+        Reset to {this.getMetadataForAction().title}
       </Link>
     );
   }
@@ -268,9 +266,9 @@ class Admin extends React.Component {
                 <div className="row">
                   <div className="col-12 col-md-6 pt-1 pb-3">
                     {lastUpdatedDate &&
-                      <span>
+                      <React.Fragment>
                         Showing data as of {formatTimestamp({ timestamp: lastUpdatedDate })}
-                      </span>
+                      </React.Fragment>
                     }
                   </div>
                   <div className="col-12 col-md-6 text-md-right">

--- a/src/components/CompletedLearnersTable/__snapshots__/CompletedLearnersTable.test.jsx.snap
+++ b/src/components/CompletedLearnersTable/__snapshots__/CompletedLearnersTable.test.jsx.snap
@@ -1,32 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CompletedLearnersTable renders empty state correctly 1`] = `
-<div>
+<div
+  className="alert fade alert-warning show"
+  hidden={false}
+  role="alert"
+>
   <div
-    className="alert fade alert-warning show"
-    hidden={false}
-    role="alert"
+    className="alert-dialog"
   >
     <div
-      className="alert-dialog"
+      className="d-flex"
     >
       <div
-        className="d-flex"
+        className="icon mr-2"
       >
-        <div
-          className="icon mr-2"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-exclamation-circle"
-            id="Icon1"
-          />
-        </div>
-        <div
-          className="message"
-        >
-          There are no results.
-        </div>
+        <span
+          aria-hidden={true}
+          className="fa fa-exclamation-circle"
+          id="Icon1"
+        />
+      </div>
+      <div
+        className="message"
+      >
+        There are no results.
       </div>
     </div>
   </div>

--- a/src/components/EnrolledLearnersForInactiveCoursesTable/__snapshots__/EnrolledLearnersForInactiveCoursesTable.test.jsx.snap
+++ b/src/components/EnrolledLearnersForInactiveCoursesTable/__snapshots__/EnrolledLearnersForInactiveCoursesTable.test.jsx.snap
@@ -1,32 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EnrolledLearnersForInactiveCoursesTable renders empty state correctly 1`] = `
-<div>
+<div
+  className="alert fade alert-warning show"
+  hidden={false}
+  role="alert"
+>
   <div
-    className="alert fade alert-warning show"
-    hidden={false}
-    role="alert"
+    className="alert-dialog"
   >
     <div
-      className="alert-dialog"
+      className="d-flex"
     >
       <div
-        className="d-flex"
+        className="icon mr-2"
       >
-        <div
-          className="icon mr-2"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-exclamation-circle"
-            id="Icon1"
-          />
-        </div>
-        <div
-          className="message"
-        >
-          There are no results.
-        </div>
+        <span
+          aria-hidden={true}
+          className="fa fa-exclamation-circle"
+          id="Icon1"
+        />
+      </div>
+      <div
+        className="message"
+      >
+        There are no results.
       </div>
     </div>
   </div>
@@ -34,288 +32,286 @@ exports[`EnrolledLearnersForInactiveCoursesTable renders empty state correctly 1
 `;
 
 exports[`EnrolledLearnersForInactiveCoursesTable renders enrolled learners for inactive courses table correctly 1`] = `
-<div>
+<div
+  className="enrolled-learners-inactive-courses"
+>
   <div
-    className="enrolled-learners-inactive-courses"
+    className="row"
   >
     <div
-      className="row"
+      className="col"
     >
       <div
-        className="col"
+        className="table-responsive"
       >
-        <div
-          className="table-responsive"
+        <table
+          className="table table-sm table-striped"
         >
-          <table
-            className="table table-sm table-striped"
+          <thead
+            className=""
           >
-            <thead
+            <tr
               className=""
             >
-              <tr
-                className=""
+              <th
+                className="sortable"
+                scope="col"
               >
-                <th
-                  className="sortable"
-                  scope="col"
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Email
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        sort ascending
-                      </span>
+                  <span>
+                    Email
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort-asc"
-                      />
+                      sort ascending
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort-asc"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Total Course Enrollment Count
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Total Course Enrollment Count
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Total Completed Courses Count
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Total Completed Courses Count
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Last Activity Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Last Activity Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            className=""
+          >
+            <tr
               className=""
             >
-              <tr
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  test_user_1@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  2
-                </td>
-                <td
-                  className=""
-                >
-                  1
-                </td>
-                <td
-                  className=""
-                >
-                  June 23, 2017
-                </td>
-              </tr>
-              <tr
+                test_user_1@example.com
+              </td>
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  test_user_2@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  5
-                </td>
-                <td
-                  className=""
-                >
-                  5
-                </td>
-                <td
-                  className=""
-                >
-                  January 15, 2018
-                </td>
-              </tr>
-              <tr
+                2
+              </td>
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  test_user_3@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  6
-                </td>
-                <td
-                  className=""
-                >
-                  4
-                </td>
-                <td
-                  className=""
-                >
-                  November 18, 2017
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                1
+              </td>
+              <td
+                className=""
+              >
+                June 23, 2017
+              </td>
+            </tr>
+            <tr
+              className=""
+            >
+              <td
+                className=""
+              >
+                test_user_2@example.com
+              </td>
+              <td
+                className=""
+              >
+                5
+              </td>
+              <td
+                className=""
+              >
+                5
+              </td>
+              <td
+                className=""
+              >
+                January 15, 2018
+              </td>
+            </tr>
+            <tr
+              className=""
+            >
+              <td
+                className=""
+              >
+                test_user_3@example.com
+              </td>
+              <td
+                className=""
+              >
+                6
+              </td>
+              <td
+                className=""
+              >
+                4
+              </td>
+              <td
+                className=""
+              >
+                November 18, 2017
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col d-flex justify-content-center"
     >
-      <div
-        className="col d-flex justify-content-center"
+      <nav
+        aria-label="enrolled-learners-inactive-courses-pagination"
+        className=""
       >
-        <nav
-          aria-label="enrolled-learners-inactive-courses-pagination"
-          className=""
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          aria-relevant="text"
+          className="sr-only"
         >
-          <div
-            aria-atomic={true}
-            aria-live="polite"
-            aria-relevant="text"
-            className="sr-only"
+          Page 1, Current Page, of 1
+        </div>
+        <ul
+          className="pagination"
+        >
+          <li
+            className="page-item disabled"
           >
-            Page 1, Current Page, of 1
-          </div>
-          <ul
-            className="pagination"
+            <button
+              aria-label="Previous"
+              className="btn previous page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
+            >
+              <div>
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-left mr-2"
+                  id="pagination-2"
+                />
+                Previous
+              </div>
+            </button>
+          </li>
+          <li
+            className="page-item disabled"
           >
-            <li
-              className="page-item disabled"
+            <button
+              aria-label="Next"
+              className="btn next page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
             >
-              <button
-                aria-label="Previous"
-                className="btn previous page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-left mr-2"
-                    id="pagination-2"
-                  />
-                  Previous
-                </div>
-              </button>
-            </li>
-            <li
-              className="page-item disabled"
-            >
-              <button
-                aria-label="Next"
-                className="btn next page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  Next
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-right ml-2"
-                    id="pagination-3"
-                  />
-                </div>
-              </button>
-            </li>
-          </ul>
-        </nav>
-      </div>
+              <div>
+                Next
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-right ml-2"
+                  id="pagination-3"
+                />
+              </div>
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </div>

--- a/src/components/EnrolledLearnersTable/__snapshots__/EnrolledLearnersTable.test.jsx.snap
+++ b/src/components/EnrolledLearnersTable/__snapshots__/EnrolledLearnersTable.test.jsx.snap
@@ -1,32 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EnrolledLearnersTable renders empty state correctly 1`] = `
-<div>
+<div
+  className="alert fade alert-warning show"
+  hidden={false}
+  role="alert"
+>
   <div
-    className="alert fade alert-warning show"
-    hidden={false}
-    role="alert"
+    className="alert-dialog"
   >
     <div
-      className="alert-dialog"
+      className="d-flex"
     >
       <div
-        className="d-flex"
+        className="icon mr-2"
       >
-        <div
-          className="icon mr-2"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-exclamation-circle"
-            id="Icon1"
-          />
-        </div>
-        <div
-          className="message"
-        >
-          There are no results.
-        </div>
+        <span
+          aria-hidden={true}
+          className="fa fa-exclamation-circle"
+          id="Icon1"
+        />
+      </div>
+      <div
+        className="message"
+      >
+        There are no results.
       </div>
     </div>
   </div>

--- a/src/components/EnrollmentsTable/__snapshots__/EnrollmentsTable.test.jsx.snap
+++ b/src/components/EnrollmentsTable/__snapshots__/EnrollmentsTable.test.jsx.snap
@@ -1,32 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EnrollmentsTable renders empty state correctly 1`] = `
-<div>
+<div
+  className="alert fade alert-warning show"
+  hidden={false}
+  role="alert"
+>
   <div
-    className="alert fade alert-warning show"
-    hidden={false}
-    role="alert"
+    className="alert-dialog"
   >
     <div
-      className="alert-dialog"
+      className="d-flex"
     >
       <div
-        className="d-flex"
+        className="icon mr-2"
       >
-        <div
-          className="icon mr-2"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-exclamation-circle"
-            id="Icon1"
-          />
-        </div>
-        <div
-          className="message"
-        >
-          There are no results.
-        </div>
+        <span
+          aria-hidden={true}
+          className="fa fa-exclamation-circle"
+          id="Icon1"
+        />
+      </div>
+      <div
+        className="message"
+      >
+        There are no results.
       </div>
     </div>
   </div>

--- a/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
+++ b/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
@@ -98,9 +98,7 @@ exports[`<EnterpriseList /> renders correctly call clearPortalConfiguration prop
   >
     <div
       className="col"
-    >
-      <div />
-    </div>
+    />
   </div>
 </div>
 `;
@@ -203,9 +201,7 @@ exports[`<EnterpriseList /> renders correctly with empty enterprises data 1`] = 
   >
     <div
       className="col"
-    >
-      <div />
-    </div>
+    />
   </div>
 </div>
 `;
@@ -308,9 +304,7 @@ exports[`<EnterpriseList /> renders correctly with enterprises data 1`] = `
   >
     <div
       className="col"
-    >
-      <div />
-    </div>
+    />
   </div>
 </div>
 `;
@@ -413,9 +407,7 @@ exports[`<EnterpriseList /> renders correctly with error state 1`] = `
   >
     <div
       className="col"
-    >
-      <div />
-    </div>
+    />
   </div>
 </div>
 `;
@@ -518,9 +510,7 @@ exports[`<EnterpriseList /> renders correctly with loading state 1`] = `
   >
     <div
       className="col"
-    >
-      <div />
-    </div>
+    />
   </div>
 </div>
 `;
@@ -643,9 +633,7 @@ exports[`<EnterpriseList /> renders correctly with search query and empty enterp
   >
     <div
       className="col"
-    >
-      <div />
-    </div>
+    />
   </div>
 </div>
 `;

--- a/src/components/LearnerActivityTable/__snapshots__/LearnerActivityTable.test.jsx.snap
+++ b/src/components/LearnerActivityTable/__snapshots__/LearnerActivityTable.test.jsx.snap
@@ -1,444 +1,440 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LearnerActivityTable renders active learners table correctly 1`] = `
-<div>
+<div
+  className="active-week"
+>
   <div
-    className="active-week"
+    className="row"
   >
     <div
-      className="row"
+      className="col"
     >
       <div
-        className="col"
+        className="table-responsive"
       >
-        <div
-          className="table-responsive"
+        <table
+          className="table table-sm table-striped"
         >
-          <table
-            className="table table-sm table-striped"
+          <thead
+            className=""
           >
-            <thead
+            <tr
               className=""
             >
-              <tr
-                className=""
+              <th
+                className="sortable"
+                scope="col"
               >
-                <th
-                  className="sortable"
-                  scope="col"
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Email
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        sort ascending
-                      </span>
+                  <span>
+                    Email
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort-asc"
-                      />
+                      sort ascending
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort-asc"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Course Title
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Course Title
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Course Price
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Course Price
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Start Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Start Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      End Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    End Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Passed Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Passed Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Current Grade
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Current Grade
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Last Activity Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Last Activity Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            className=""
+          >
+            <tr
               className=""
             >
-              <tr
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  awesome.me@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  Dive into ReactJS
-                </td>
-                <td
-                  className=""
-                >
-                  $200
-                </td>
-                <td
-                  className=""
-                >
-                  October 21, 2017
-                </td>
-                <td
-                  className=""
-                >
-                  May 13, 2018
-                </td>
-                <td
-                  className=""
-                >
-                  September 23, 2018
-                </td>
-                <td
-                  className=""
-                >
-                  66%
-                </td>
-                <td
-                  className=""
-                >
-                  September 22, 2018
-                </td>
-              </tr>
-              <tr
+                awesome.me@example.com
+              </td>
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  new@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  Redux with ReactJS
-                </td>
-                <td
-                  className=""
-                >
-                  $200
-                </td>
-                <td
-                  className=""
-                >
-                  October 21, 2017
-                </td>
-                <td
-                  className=""
-                >
-                  May 13, 2018
-                </td>
-                <td
-                  className=""
-                >
-                  September 22, 2018
-                </td>
-                <td
-                  className=""
-                >
-                  80%
-                </td>
-                <td
-                  className=""
-                >
-                  September 25, 2018
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                Dive into ReactJS
+              </td>
+              <td
+                className=""
+              >
+                $200
+              </td>
+              <td
+                className=""
+              >
+                October 21, 2017
+              </td>
+              <td
+                className=""
+              >
+                May 13, 2018
+              </td>
+              <td
+                className=""
+              >
+                September 23, 2018
+              </td>
+              <td
+                className=""
+              >
+                66%
+              </td>
+              <td
+                className=""
+              >
+                September 22, 2018
+              </td>
+            </tr>
+            <tr
+              className=""
+            >
+              <td
+                className=""
+              >
+                new@example.com
+              </td>
+              <td
+                className=""
+              >
+                Redux with ReactJS
+              </td>
+              <td
+                className=""
+              >
+                $200
+              </td>
+              <td
+                className=""
+              >
+                October 21, 2017
+              </td>
+              <td
+                className=""
+              >
+                May 13, 2018
+              </td>
+              <td
+                className=""
+              >
+                September 22, 2018
+              </td>
+              <td
+                className=""
+              >
+                80%
+              </td>
+              <td
+                className=""
+              >
+                September 25, 2018
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col d-flex justify-content-center"
     >
-      <div
-        className="col d-flex justify-content-center"
+      <nav
+        aria-label="active-week-pagination"
+        className=""
       >
-        <nav
-          aria-label="active-week-pagination"
-          className=""
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          aria-relevant="text"
+          className="sr-only"
         >
-          <div
-            aria-atomic={true}
-            aria-live="polite"
-            aria-relevant="text"
-            className="sr-only"
+          Page 1, Current Page, of 1
+        </div>
+        <ul
+          className="pagination"
+        >
+          <li
+            className="page-item disabled"
           >
-            Page 1, Current Page, of 1
-          </div>
-          <ul
-            className="pagination"
+            <button
+              aria-label="Previous"
+              className="btn previous page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
+            >
+              <div>
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-left mr-2"
+                  id="pagination-2"
+                />
+                Previous
+              </div>
+            </button>
+          </li>
+          <li
+            className="page-item disabled"
           >
-            <li
-              className="page-item disabled"
+            <button
+              aria-label="Next"
+              className="btn next page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
             >
-              <button
-                aria-label="Previous"
-                className="btn previous page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-left mr-2"
-                    id="pagination-2"
-                  />
-                  Previous
-                </div>
-              </button>
-            </li>
-            <li
-              className="page-item disabled"
-            >
-              <button
-                aria-label="Next"
-                className="btn next page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  Next
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-right ml-2"
-                    id="pagination-3"
-                  />
-                </div>
-              </button>
-            </li>
-          </ul>
-        </nav>
-      </div>
+              <div>
+                Next
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-right ml-2"
+                  id="pagination-3"
+                />
+              </div>
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </div>
 `;
 
 exports[`LearnerActivityTable renders empty state correctly 1`] = `
-<div>
+<div
+  className="alert fade alert-warning show"
+  hidden={false}
+  role="alert"
+>
   <div
-    className="alert fade alert-warning show"
-    hidden={false}
-    role="alert"
+    className="alert-dialog"
   >
     <div
-      className="alert-dialog"
+      className="d-flex"
     >
       <div
-        className="d-flex"
+        className="icon mr-2"
       >
-        <div
-          className="icon mr-2"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-exclamation-circle"
-            id="Icon1"
-          />
-        </div>
-        <div
-          className="message"
-        >
-          There are no results.
-        </div>
+        <span
+          aria-hidden={true}
+          className="fa fa-exclamation-circle"
+          id="Icon1"
+        />
+      </div>
+      <div
+        className="message"
+      >
+        There are no results.
       </div>
     </div>
   </div>
@@ -446,750 +442,746 @@ exports[`LearnerActivityTable renders empty state correctly 1`] = `
 `;
 
 exports[`LearnerActivityTable renders inactive past month learners table correctly 1`] = `
-<div>
+<div
+  className="inactive-month"
+>
   <div
-    className="inactive-month"
+    className="row"
   >
     <div
-      className="row"
+      className="col"
     >
       <div
-        className="col"
+        className="table-responsive"
       >
-        <div
-          className="table-responsive"
+        <table
+          className="table table-sm table-striped"
         >
-          <table
-            className="table table-sm table-striped"
+          <thead
+            className=""
           >
-            <thead
+            <tr
               className=""
             >
-              <tr
-                className=""
+              <th
+                className="sortable"
+                scope="col"
               >
-                <th
-                  className="sortable"
-                  scope="col"
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Email
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        sort ascending
-                      </span>
+                  <span>
+                    Email
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort-asc"
-                      />
+                      sort ascending
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort-asc"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Course Title
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Course Title
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Course Price
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Course Price
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Start Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Start Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      End Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    End Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Current Grade
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Current Grade
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Last Activity Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Last Activity Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            className=""
+          >
+            <tr
               className=""
             >
-              <tr
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  awesome.me@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  Dive into ReactJS
-                </td>
-                <td
-                  className=""
-                >
-                  $200
-                </td>
-                <td
-                  className=""
-                >
-                  October 21, 2017
-                </td>
-                <td
-                  className=""
-                >
-                  May 13, 2018
-                </td>
-                <td
-                  className=""
-                >
-                  66%
-                </td>
-                <td
-                  className=""
-                >
-                  September 22, 2018
-                </td>
-              </tr>
-              <tr
+                awesome.me@example.com
+              </td>
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  new@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  Redux with ReactJS
-                </td>
-                <td
-                  className=""
-                >
-                  $200
-                </td>
-                <td
-                  className=""
-                >
-                  October 21, 2017
-                </td>
-                <td
-                  className=""
-                >
-                  May 13, 2018
-                </td>
-                <td
-                  className=""
-                >
-                  80%
-                </td>
-                <td
-                  className=""
-                >
-                  September 25, 2018
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                Dive into ReactJS
+              </td>
+              <td
+                className=""
+              >
+                $200
+              </td>
+              <td
+                className=""
+              >
+                October 21, 2017
+              </td>
+              <td
+                className=""
+              >
+                May 13, 2018
+              </td>
+              <td
+                className=""
+              >
+                66%
+              </td>
+              <td
+                className=""
+              >
+                September 22, 2018
+              </td>
+            </tr>
+            <tr
+              className=""
+            >
+              <td
+                className=""
+              >
+                new@example.com
+              </td>
+              <td
+                className=""
+              >
+                Redux with ReactJS
+              </td>
+              <td
+                className=""
+              >
+                $200
+              </td>
+              <td
+                className=""
+              >
+                October 21, 2017
+              </td>
+              <td
+                className=""
+              >
+                May 13, 2018
+              </td>
+              <td
+                className=""
+              >
+                80%
+              </td>
+              <td
+                className=""
+              >
+                September 25, 2018
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col d-flex justify-content-center"
     >
-      <div
-        className="col d-flex justify-content-center"
+      <nav
+        aria-label="inactive-month-pagination"
+        className=""
       >
-        <nav
-          aria-label="inactive-month-pagination"
-          className=""
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          aria-relevant="text"
+          className="sr-only"
         >
-          <div
-            aria-atomic={true}
-            aria-live="polite"
-            aria-relevant="text"
-            className="sr-only"
+          Page 1, Current Page, of 1
+        </div>
+        <ul
+          className="pagination"
+        >
+          <li
+            className="page-item disabled"
           >
-            Page 1, Current Page, of 1
-          </div>
-          <ul
-            className="pagination"
+            <button
+              aria-label="Previous"
+              className="btn previous page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
+            >
+              <div>
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-left mr-2"
+                  id="pagination-6"
+                />
+                Previous
+              </div>
+            </button>
+          </li>
+          <li
+            className="page-item disabled"
           >
-            <li
-              className="page-item disabled"
+            <button
+              aria-label="Next"
+              className="btn next page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
             >
-              <button
-                aria-label="Previous"
-                className="btn previous page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-left mr-2"
-                    id="pagination-6"
-                  />
-                  Previous
-                </div>
-              </button>
-            </li>
-            <li
-              className="page-item disabled"
-            >
-              <button
-                aria-label="Next"
-                className="btn next page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  Next
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-right ml-2"
-                    id="pagination-7"
-                  />
-                </div>
-              </button>
-            </li>
-          </ul>
-        </nav>
-      </div>
+              <div>
+                Next
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-right ml-2"
+                  id="pagination-7"
+                />
+              </div>
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </div>
 `;
 
 exports[`LearnerActivityTable renders inactive past week learners table correctly 1`] = `
-<div>
+<div
+  className="inactive-week"
+>
   <div
-    className="inactive-week"
+    className="row"
   >
     <div
-      className="row"
+      className="col"
     >
       <div
-        className="col"
+        className="table-responsive"
       >
-        <div
-          className="table-responsive"
+        <table
+          className="table table-sm table-striped"
         >
-          <table
-            className="table table-sm table-striped"
+          <thead
+            className=""
           >
-            <thead
+            <tr
               className=""
             >
-              <tr
-                className=""
+              <th
+                className="sortable"
+                scope="col"
               >
-                <th
-                  className="sortable"
-                  scope="col"
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Email
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        sort ascending
-                      </span>
+                  <span>
+                    Email
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort-asc"
-                      />
+                      sort ascending
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort-asc"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Course Title
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Course Title
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Course Price
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Course Price
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Start Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Start Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      End Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    End Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Current Grade
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Current Grade
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Last Activity Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Last Activity Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            className=""
+          >
+            <tr
               className=""
             >
-              <tr
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  awesome.me@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  Dive into ReactJS
-                </td>
-                <td
-                  className=""
-                >
-                  $200
-                </td>
-                <td
-                  className=""
-                >
-                  October 21, 2017
-                </td>
-                <td
-                  className=""
-                >
-                  May 13, 2018
-                </td>
-                <td
-                  className=""
-                >
-                  66%
-                </td>
-                <td
-                  className=""
-                >
-                  September 22, 2018
-                </td>
-              </tr>
-              <tr
+                awesome.me@example.com
+              </td>
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  new@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  Redux with ReactJS
-                </td>
-                <td
-                  className=""
-                >
-                  $200
-                </td>
-                <td
-                  className=""
-                >
-                  October 21, 2017
-                </td>
-                <td
-                  className=""
-                >
-                  May 13, 2018
-                </td>
-                <td
-                  className=""
-                >
-                  80%
-                </td>
-                <td
-                  className=""
-                >
-                  September 25, 2018
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                Dive into ReactJS
+              </td>
+              <td
+                className=""
+              >
+                $200
+              </td>
+              <td
+                className=""
+              >
+                October 21, 2017
+              </td>
+              <td
+                className=""
+              >
+                May 13, 2018
+              </td>
+              <td
+                className=""
+              >
+                66%
+              </td>
+              <td
+                className=""
+              >
+                September 22, 2018
+              </td>
+            </tr>
+            <tr
+              className=""
+            >
+              <td
+                className=""
+              >
+                new@example.com
+              </td>
+              <td
+                className=""
+              >
+                Redux with ReactJS
+              </td>
+              <td
+                className=""
+              >
+                $200
+              </td>
+              <td
+                className=""
+              >
+                October 21, 2017
+              </td>
+              <td
+                className=""
+              >
+                May 13, 2018
+              </td>
+              <td
+                className=""
+              >
+                80%
+              </td>
+              <td
+                className=""
+              >
+                September 25, 2018
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col d-flex justify-content-center"
     >
-      <div
-        className="col d-flex justify-content-center"
+      <nav
+        aria-label="inactive-week-pagination"
+        className=""
       >
-        <nav
-          aria-label="inactive-week-pagination"
-          className=""
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          aria-relevant="text"
+          className="sr-only"
         >
-          <div
-            aria-atomic={true}
-            aria-live="polite"
-            aria-relevant="text"
-            className="sr-only"
+          Page 1, Current Page, of 1
+        </div>
+        <ul
+          className="pagination"
+        >
+          <li
+            className="page-item disabled"
           >
-            Page 1, Current Page, of 1
-          </div>
-          <ul
-            className="pagination"
+            <button
+              aria-label="Previous"
+              className="btn previous page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
+            >
+              <div>
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-left mr-2"
+                  id="pagination-4"
+                />
+                Previous
+              </div>
+            </button>
+          </li>
+          <li
+            className="page-item disabled"
           >
-            <li
-              className="page-item disabled"
+            <button
+              aria-label="Next"
+              className="btn next page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
             >
-              <button
-                aria-label="Previous"
-                className="btn previous page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-left mr-2"
-                    id="pagination-4"
-                  />
-                  Previous
-                </div>
-              </button>
-            </li>
-            <li
-              className="page-item disabled"
-            >
-              <button
-                aria-label="Next"
-                className="btn next page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  Next
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-right ml-2"
-                    id="pagination-5"
-                  />
-                </div>
-              </button>
-            </li>
-          </ul>
-        </nav>
-      </div>
+              <div>
+                Next
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-right ml-2"
+                  id="pagination-5"
+                />
+              </div>
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </div>

--- a/src/components/LoadingMessage/index.jsx
+++ b/src/components/LoadingMessage/index.jsx
@@ -7,8 +7,13 @@ import './LoadingMessage.scss';
 const LoadingMessage = (props) => {
   const { className } = props;
   return (
-    <div className={classNames(className, 'loading d-flex align-items-center justify-content-center')}>
-      <span>Loading...</span>
+    <div
+      className={classNames(
+        'loading d-flex align-items-center justify-content-center',
+        className,
+      )}
+    >
+      Loading...
     </div>
   );
 };

--- a/src/components/PastWeekPassedLearnersTable/__snapshots__/PastWeekPassedLearnersTable.test.jsx.snap
+++ b/src/components/PastWeekPassedLearnersTable/__snapshots__/PastWeekPassedLearnersTable.test.jsx.snap
@@ -1,227 +1,225 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PastWeekPassedLearnersTable renders table correctly 1`] = `
-<div>
+<div
+  className="completed-learners-week"
+>
   <div
-    className="completed-learners-week"
+    className="row"
   >
     <div
-      className="row"
+      className="col"
     >
       <div
-        className="col"
+        className="table-responsive"
       >
-        <div
-          className="table-responsive"
+        <table
+          className="table table-sm table-striped"
         >
-          <table
-            className="table table-sm table-striped"
+          <thead
+            className=""
           >
-            <thead
+            <tr
               className=""
             >
-              <tr
-                className=""
+              <th
+                className="sortable"
+                scope="col"
               >
-                <th
-                  className="sortable"
-                  scope="col"
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Email
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        sort ascending
-                      </span>
+                  <span>
+                    Email
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort-asc"
-                      />
+                      sort ascending
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort-asc"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Course Title
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Course Title
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-                <th
-                  className="sortable"
-                  scope="col"
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+              <th
+                className="sortable"
+                scope="col"
+              >
+                <button
+                  className="btn btn-header"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
                 >
-                  <button
-                    className="btn btn-header"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    type="button"
-                  >
-                    <span>
-                      Passed Date
-                      <span
-                        className="sr-only"
-                      >
-                         
-                        click to sort
-                      </span>
+                  <span>
+                    Passed Date
+                    <span
+                      className="sr-only"
+                    >
                        
-                      <span
-                        aria-hidden={true}
-                        className="fa fa-sort"
-                      />
+                      click to sort
                     </span>
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
+                     
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-sort"
+                    />
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            className=""
+          >
+            <tr
               className=""
             >
-              <tr
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  awesome.me@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  Dive into ReactJS
-                </td>
-                <td
-                  className=""
-                >
-                  September 23, 2018
-                </td>
-              </tr>
-              <tr
+                awesome.me@example.com
+              </td>
+              <td
                 className=""
               >
-                <td
-                  className=""
-                >
-                  new@example.com
-                </td>
-                <td
-                  className=""
-                >
-                  Redux with ReactJS
-                </td>
-                <td
-                  className=""
-                >
-                  September 22, 2018
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                Dive into ReactJS
+              </td>
+              <td
+                className=""
+              >
+                September 23, 2018
+              </td>
+            </tr>
+            <tr
+              className=""
+            >
+              <td
+                className=""
+              >
+                new@example.com
+              </td>
+              <td
+                className=""
+              >
+                Redux with ReactJS
+              </td>
+              <td
+                className=""
+              >
+                September 22, 2018
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
+  </div>
+  <div
+    className="row mt-2"
+  >
     <div
-      className="row mt-2"
+      className="col d-flex justify-content-center"
     >
-      <div
-        className="col d-flex justify-content-center"
+      <nav
+        aria-label="completed-learners-week-pagination"
+        className=""
       >
-        <nav
-          aria-label="completed-learners-week-pagination"
-          className=""
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          aria-relevant="text"
+          className="sr-only"
         >
-          <div
-            aria-atomic={true}
-            aria-live="polite"
-            aria-relevant="text"
-            className="sr-only"
+          Page 1, Current Page, of 1
+        </div>
+        <ul
+          className="pagination"
+        >
+          <li
+            className="page-item disabled"
           >
-            Page 1, Current Page, of 1
-          </div>
-          <ul
-            className="pagination"
+            <button
+              aria-label="Previous"
+              className="btn previous page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
+            >
+              <div>
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-left mr-2"
+                  id="pagination-2"
+                />
+                Previous
+              </div>
+            </button>
+          </li>
+          <li
+            className="page-item disabled"
           >
-            <li
-              className="page-item disabled"
+            <button
+              aria-label="Next"
+              className="btn next page-link"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex="-1"
+              type="button"
             >
-              <button
-                aria-label="Previous"
-                className="btn previous page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-left mr-2"
-                    id="pagination-2"
-                  />
-                  Previous
-                </div>
-              </button>
-            </li>
-            <li
-              className="page-item disabled"
-            >
-              <button
-                aria-label="Next"
-                className="btn next page-link"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                tabIndex="-1"
-                type="button"
-              >
-                <div>
-                  Next
-                  <span
-                    aria-hidden={true}
-                    className="fa fa-chevron-right ml-2"
-                    id="pagination-3"
-                  />
-                </div>
-              </button>
-            </li>
-          </ul>
-        </nav>
-      </div>
+              <div>
+                Next
+                <span
+                  aria-hidden={true}
+                  className="fa fa-chevron-right ml-2"
+                  id="pagination-3"
+                />
+              </div>
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </div>

--- a/src/components/RegisteredLearnersTable/__snapshots__/RegisteredLearnersTable.test.jsx.snap
+++ b/src/components/RegisteredLearnersTable/__snapshots__/RegisteredLearnersTable.test.jsx.snap
@@ -1,32 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RegisteredLearnersTable renders empty state correctly 1`] = `
-<div>
+<div
+  className="alert fade alert-warning show"
+  hidden={false}
+  role="alert"
+>
   <div
-    className="alert fade alert-warning show"
-    hidden={false}
-    role="alert"
+    className="alert-dialog"
   >
     <div
-      className="alert-dialog"
+      className="d-flex"
     >
       <div
-        className="d-flex"
+        className="icon mr-2"
       >
-        <div
-          className="icon mr-2"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-exclamation-circle"
-            id="Icon1"
-          />
-        </div>
-        <div
-          className="message"
-        >
-          There are no results.
-        </div>
+        <span
+          aria-hidden={true}
+          className="fa fa-exclamation-circle"
+          id="Icon1"
+        />
+      </div>
+      <div
+        className="message"
+      >
+        There are no results.
       </div>
     </div>
   </div>

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -132,14 +132,14 @@ class TableComponent extends React.Component {
     } = this.props;
 
     return (
-      <div>
+      <React.Fragment>
         {error && this.renderErrorMessage()}
         {loading && !data && this.renderLoadingMessage()}
         {!loading && !error && data && data.length === 0 &&
           this.renderEmptyDataMessage()
         }
         {data && data.length > 0 && this.renderTableContent()}
-      </div>
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
I noticed a few other places where we had unnecessary DOM wrapper elements:
- `<div>`'s with no other purpose as to wrap multiple elements. These were replaced with `<React.Fragment>`.
- `<span>`'s around text. These spans were removed and replaced with `<React.Fragment>` where needed.

This caused several snapshots to change, but confirmed that they are rendering the expected DOM nodes.