### PR TITLE
Refactor to use `.container-fluid` instead of `.container`

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -6,7 +6,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -32,7 +32,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -133,7 +133,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -159,7 +159,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -709,7 +709,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -735,7 +735,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -1285,7 +1285,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -1311,7 +1311,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -1866,7 +1866,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -1892,7 +1892,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -2429,7 +2429,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -2455,7 +2455,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -2992,7 +2992,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -3018,7 +3018,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -3573,7 +3573,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -3599,7 +3599,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -4154,7 +4154,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -4180,7 +4180,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -4733,7 +4733,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -4759,7 +4759,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -5309,7 +5309,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -5335,7 +5335,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -5890,7 +5890,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -5916,7 +5916,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"
@@ -6025,7 +6025,7 @@ Array [
     className="hero py-4 pt-md-5 pb-md-0"
   >
     <div
-      className="container"
+      className="container-fluid"
     >
       <div
         className="row"
@@ -6051,7 +6051,7 @@ Array [
     </div>
   </div>,
   <div
-    className="container"
+    className="container-fluid"
   >
     <div
       className="row mt-4"

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -237,7 +237,7 @@ class Admin extends React.Component {
           <title>Learner and Progress Report</title>
         </Helmet>
         <Hero title="Learner and Progress Report" />
-        <div className="container">
+        <div className="container-fluid">
           <div className="row mt-4">
             <div className="col">
               <H2>Overview</H2>

--- a/src/components/CodeManagement/index.jsx
+++ b/src/components/CodeManagement/index.jsx
@@ -164,7 +164,7 @@ class CodeManagement extends React.Component {
           <title>Code Management</title>
         </Helmet>
         <Hero title="Code Management" />
-        <div className="container">
+        <div className="container-fluid">
           {hasRequestedCodes && this.renderRequestCodesSuccessMessage()}
           <div className="row mt-4 mb-3">
             <div className="col-12 col-md-3 mb-2 mb-md-0">

--- a/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
+++ b/src/components/EnterpriseList/__snapshots__/EnterpriseList.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<EnterpriseList /> renders correctly call clearPortalConfiguration prop 1`] = `
 <div
-  className="container"
+  className="container-fluid"
 >
   <div
     className="row mt-4"
@@ -105,7 +105,7 @@ exports[`<EnterpriseList /> renders correctly call clearPortalConfiguration prop
 
 exports[`<EnterpriseList /> renders correctly with empty enterprises data 1`] = `
 <div
-  className="container"
+  className="container-fluid"
 >
   <div
     className="row mt-4"
@@ -208,7 +208,7 @@ exports[`<EnterpriseList /> renders correctly with empty enterprises data 1`] = 
 
 exports[`<EnterpriseList /> renders correctly with enterprises data 1`] = `
 <div
-  className="container"
+  className="container-fluid"
 >
   <div
     className="row mt-4"
@@ -311,7 +311,7 @@ exports[`<EnterpriseList /> renders correctly with enterprises data 1`] = `
 
 exports[`<EnterpriseList /> renders correctly with error state 1`] = `
 <div
-  className="container"
+  className="container-fluid"
 >
   <div
     className="row mt-4"
@@ -414,7 +414,7 @@ exports[`<EnterpriseList /> renders correctly with error state 1`] = `
 
 exports[`<EnterpriseList /> renders correctly with loading state 1`] = `
 <div
-  className="container"
+  className="container-fluid"
 >
   <div
     className="row mt-4"
@@ -517,7 +517,7 @@ exports[`<EnterpriseList /> renders correctly with loading state 1`] = `
 
 exports[`<EnterpriseList /> renders correctly with search query and empty enterprises data 1`] = `
 <div
-  className="container"
+  className="container-fluid"
 >
   <div
     className="row mt-4"

--- a/src/components/EnterpriseList/index.jsx
+++ b/src/components/EnterpriseList/index.jsx
@@ -100,7 +100,7 @@ class EnterpriseList extends React.Component {
         <Helmet>
           <title>Enterprise List</title>
         </Helmet>
-        <div className="container">
+        <div className="container-fluid">
           <div className="row mt-4">
             <div className="col-sm-12 col-md">
               <H1>Enterprise List</H1>

--- a/src/components/ErrorPage/__snapshots__/ErrorPage.test.jsx.snap
+++ b/src/components/ErrorPage/__snapshots__/ErrorPage.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ErrorPage /> renders correctly 1`] = `
 <div
-  className="container"
+  className="container-fluid"
 >
   <div
     className="row mt-4"
@@ -41,10 +41,10 @@ exports[`<ErrorPage /> renders correctly 1`] = `
 
 exports[`<ErrorPage /> renders correctly for 404 errors 1`] = `
 <div
-  className="container"
+  className="container-fluid"
 >
   <div
-    className="container mt-3"
+    className="container-fluid mt-3"
   >
     <div
       className="text-center py-5"

--- a/src/components/ErrorPage/index.jsx
+++ b/src/components/ErrorPage/index.jsx
@@ -10,7 +10,7 @@ const ErrorPage = (props) => {
   const errorMessage = props.message || 'An unknown error has occured.';
 
   return (
-    <div className="container">
+    <div className="container-fluid">
       {props.status === 404 ? (
         <NotFoundPage />
       ) : (

--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -41,7 +41,7 @@ class Footer extends React.Component {
     const { enterpriseLogoNotFound } = this.state;
     const { enterpriseLogo, enterpriseSlug } = this.props;
     return (
-      <footer className="container pb-4">
+      <footer className="container-fluid pb-4">
         <div className="row justify-content-between align-items-center">
           <div className="col-xs-12 col-md-4 logo-links">
             <Link className="logo" to="/">

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -38,7 +38,7 @@ class Header extends React.Component {
   render() {
     const { email } = this.props;
     return (
-      <header className="container">
+      <header className="container-fluid">
         <nav className="navbar px-0 justify-content-between">
           <div>
             <Link

--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -8,7 +8,7 @@ import './Hero.scss';
 
 const Hero = props => (
   <div className="hero py-4 pt-md-5 pb-md-0">
-    <div className="container">
+    <div className="container-fluid">
       <div className="row">
         <div className="col-12 col-md-9 mb-2 mb-md-1">
           <H1>{props.title}</H1>

--- a/src/components/NotFoundPage/__snapshots__/NotFoundPage.test.jsx.snap
+++ b/src/components/NotFoundPage/__snapshots__/NotFoundPage.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<NotFoundPage /> renders correctly 1`] = `
 <div
-  className="container mt-3"
+  className="container-fluid mt-3"
 >
   <div
     className="text-center py-5"

--- a/src/components/NotFoundPage/index.jsx
+++ b/src/components/NotFoundPage/index.jsx
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 import H1 from '../../components/H1';
 
 const NotFoundPage = () => (
-  <div className="container mt-3">
+  <div className="container-fluid mt-3">
     <Helmet>
       <title>Page Not Found</title>
     </Helmet>

--- a/src/components/RequestCodesPage/index.jsx
+++ b/src/components/RequestCodesPage/index.jsx
@@ -47,7 +47,7 @@ class RequestCodesPage extends React.Component {
           <title>Request More Codes</title>
         </Helmet>
         <Hero title="Request More Codes" />
-        <div className="container">
+        <div className="container-fluid">
           <div className="row my-3">
             <div className="col-12 col-md-5">
               <form>

--- a/src/components/SupportPage/__snapshots__/SupportPage.test.jsx.snap
+++ b/src/components/SupportPage/__snapshots__/SupportPage.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SupportPage /> renders correctly 1`] = `
 <div
-  className="container mt-3"
+  className="container-fluid mt-3"
 >
   <h1
     className={null}

--- a/src/components/SupportPage/index.jsx
+++ b/src/components/SupportPage/index.jsx
@@ -5,7 +5,7 @@ import { MailtoLink } from '@edx/paragon';
 import H1 from '../../components/H1';
 
 const SupportPage = () => (
-  <div className="container mt-3">
+  <div className="container-fluid mt-3">
     <Helmet>
       <title>Support</title>
     </Helmet>

--- a/src/containers/EnterpriseApp/__snapshots__/EnterpriseApp.test.jsx.snap
+++ b/src/containers/EnterpriseApp/__snapshots__/EnterpriseApp.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EnterpriseApp renders not found page correctly 1`] = `
 <div
-  className="container mt-3"
+  className="container-fluid mt-3"
 >
   <div
     className="text-center py-5"

--- a/src/containers/Footer/__snapshots__/Footer.test.jsx.snap
+++ b/src/containers/Footer/__snapshots__/Footer.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Footer /> renders edX logo correctly 1`] = `
 <footer
-  className="container pb-4"
+  className="container-fluid pb-4"
 >
   <div
     className="row justify-content-between align-items-center"
@@ -68,7 +68,7 @@ exports[`<Footer /> renders edX logo correctly 1`] = `
 
 exports[`<Footer /> renders enterprise logo correctly 1`] = `
 <footer
-  className="container pb-4"
+  className="container-fluid pb-4"
 >
   <div
     className="row justify-content-between align-items-center"

--- a/src/containers/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/containers/Header/__snapshots__/Header.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Header /> renders default profile image correctly 1`] = `
 <header
-  className="container"
+  className="container-fluid"
 >
   <nav
     className="navbar px-0 justify-content-between"
@@ -78,7 +78,7 @@ exports[`<Header /> renders default profile image correctly 1`] = `
 
 exports[`<Header /> renders edX logo correctly 1`] = `
 <header
-  className="container"
+  className="container-fluid"
 >
   <nav
     className="navbar px-0 justify-content-between"
@@ -107,7 +107,7 @@ exports[`<Header /> renders edX logo correctly 1`] = `
 
 exports[`<Header /> renders enterprise logo correctly 1`] = `
 <header
-  className="container"
+  className="container-fluid"
 >
   <nav
     className="navbar px-0 justify-content-between"
@@ -183,7 +183,7 @@ exports[`<Header /> renders enterprise logo correctly 1`] = `
 
 exports[`<Header /> renders profile image correctly 1`] = `
 <header
-  className="container"
+  className="container-fluid"
 >
   <nav
     className="navbar px-0 justify-content-between"


### PR DESCRIPTION
By switching to `.container-fluid` instead of the current `.container`, our pages/header/footer will fill the entire screen instead of Bootstrap's responsive widths. This will make it simpler to implement the sidebar navigation.