### PR TITLE
Update coupon demo data api response to reflect actual api fields

### DIFF
--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -25,8 +25,8 @@ const store = mockStore({
 const initialCouponData = {
   id: 1,
   title: 'Test Coupon',
-  start_date: '',
-  end_date: '',
+  start_date: '2018-06-01T12:00:00Z',
+  end_date: '2019-02-01T12:00:00Z',
   has_error: false,
   num_unassigned: 0,
   num_uses: 0,

--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import renderer from 'react-test-renderer';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+
+import Coupon from './index';
+import CouponDetails from '../CouponDetails';
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({
+  table: {
+    'coupon-details': {
+      loading: false,
+      results: [],
+    },
+  },
+  csv: {
+    'coupon-details': {},
+  },
+});
+
+const initialCouponData = {
+  id: 1,
+  title: 'Test Coupon',
+  start_date: '',
+  end_date: '',
+  has_error: false,
+  num_unassigned: 0,
+  num_uses: 0,
+  max_uses: 1,
+};
+
+const CouponWrapper = props => (
+  <MemoryRouter>
+    <Provider store={store}>
+      <Coupon
+        data={initialCouponData}
+        {...props}
+      />
+    </Provider>
+  </MemoryRouter>
+);
+
+describe('<Coupon />', () => {
+  let wrapper;
+
+  describe('renders correctly', () => {
+    it('with max uses', () => {
+      const tree = renderer
+        .create((
+          <CouponWrapper />
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('without max uses', () => {
+      const tree = renderer
+        .create((
+          <CouponWrapper
+            data={{
+              ...initialCouponData,
+              max_uses: null,
+            }}
+          />
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('with error state', () => {
+      const tree = renderer
+        .create((
+          <CouponWrapper
+            data={{
+              ...initialCouponData,
+              has_error: true,
+            }}
+          />
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('expands and collapses correctly', () => {
+    const simulateCouponClick = () => {
+      wrapper.find(Coupon).find('.metadata').simulate('click');
+    };
+
+    it('expands on click of collapsed coupon', () => {
+      const mockOnExpand = jest.fn();
+      wrapper = mount((
+        <CouponWrapper
+          onExpand={mockOnExpand}
+        />
+      ));
+
+      simulateCouponClick();
+      expect(mockOnExpand).toBeCalledTimes(1);
+      expect(wrapper.find(Coupon).find(CouponDetails).prop('expanded')).toBeTruthy();
+    });
+
+    it('collapses on click of expanded coupon', () => {
+      const mockOnCollapse = jest.fn();
+      wrapper = mount((
+        <CouponWrapper
+          onCollapse={mockOnCollapse}
+        />
+      ));
+
+      simulateCouponClick();
+      expect(wrapper.find(Coupon).find(CouponDetails).prop('expanded')).toBeTruthy();
+
+      simulateCouponClick();
+      expect(mockOnCollapse).toBeCalledTimes(1);
+      expect(wrapper.find(Coupon).find(CouponDetails).prop('expanded')).toBeFalsy();
+    });
+  });
+});

--- a/src/components/Coupon/__snapshots__/Coupon.test.jsx.snap
+++ b/src/components/Coupon/__snapshots__/Coupon.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`<Coupon /> renders correctly with error state 1`] = `
             Valid From
           </small>
           <div>
-            
+            June 1, 2018
           </div>
         </div>
         <div
@@ -52,7 +52,7 @@ exports[`<Coupon /> renders correctly with error state 1`] = `
             Valid To
           </small>
           <div>
-            
+            February 1, 2019
           </div>
         </div>
       </div>
@@ -170,7 +170,7 @@ exports[`<Coupon /> renders correctly with max uses 1`] = `
             Valid From
           </small>
           <div>
-            
+            June 1, 2018
           </div>
         </div>
         <div
@@ -182,7 +182,7 @@ exports[`<Coupon /> renders correctly with max uses 1`] = `
             Valid To
           </small>
           <div>
-            
+            February 1, 2019
           </div>
         </div>
       </div>
@@ -290,7 +290,7 @@ exports[`<Coupon /> renders correctly without max uses 1`] = `
             Valid From
           </small>
           <div>
-            
+            June 1, 2018
           </div>
         </div>
         <div
@@ -302,7 +302,7 @@ exports[`<Coupon /> renders correctly without max uses 1`] = `
             Valid To
           </small>
           <div>
-            
+            February 1, 2019
           </div>
         </div>
       </div>

--- a/src/components/Coupon/__snapshots__/Coupon.test.jsx.snap
+++ b/src/components/Coupon/__snapshots__/Coupon.test.jsx.snap
@@ -1,0 +1,366 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Coupon /> renders correctly with error state 1`] = `
+<div
+  className="coupon mb-3 mb-lg-2 rounded border border-danger"
+>
+  <div
+    aria-controls="coupon-details-1"
+    aria-expanded={false}
+    className="metadata row no-gutters p-2 d-flex align-items-center rounded"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <div
+      className="col-sm-12 col-lg-3 mb-2 mb-lg-0"
+    >
+      <small
+        className="text-muted"
+      >
+        Coupon Name
+      </small>
+      <div>
+        Test Coupon
+      </div>
+    </div>
+    <div
+      className="col-sm-12 col-lg-4 mb-2 mb-lg-0"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Valid From
+          </small>
+          <div>
+            
+          </div>
+        </div>
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Valid To
+          </small>
+          <div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="col-sm-12 col-lg-4 mb-2 mb-lg-0"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Unassigned Codes
+          </small>
+          <div>
+            0
+          </div>
+        </div>
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Enrollments Redeemed
+          </small>
+          <div>
+            0 of 1
+            <span
+              className="ml-1"
+            >
+              (0%)
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="icons col-lg-1 order-first order-lg-last text-right pr-2 mt-1 m-lg-0"
+    >
+      <span
+        aria-hidden={true}
+        className="fa fa-exclamation-circle text-danger mr-2"
+        id="Icon1"
+      />
+      <span
+        className="sr-only"
+      >
+        Coupon has an error.
+      </span>
+      <span
+        aria-hidden={true}
+        className="fa fa-chevron-down text-primary"
+        id="Icon1"
+      />
+      <span
+        className="sr-only"
+      >
+        Open coupon details
+      </span>
+    </div>
+  </div>
+  <div
+    className="coupon-details row no-gutters px-2 my-3 d-none"
+    id="coupon-details-1"
+  >
+    <div
+      className="col"
+    />
+  </div>
+</div>
+`;
+
+exports[`<Coupon /> renders correctly with max uses 1`] = `
+<div
+  className="coupon mb-3 mb-lg-2 rounded border"
+>
+  <div
+    aria-controls="coupon-details-1"
+    aria-expanded={false}
+    className="metadata row no-gutters p-2 d-flex align-items-center rounded"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <div
+      className="col-sm-12 col-lg-3 mb-2 mb-lg-0"
+    >
+      <small
+        className="text-muted"
+      >
+        Coupon Name
+      </small>
+      <div>
+        Test Coupon
+      </div>
+    </div>
+    <div
+      className="col-sm-12 col-lg-4 mb-2 mb-lg-0"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Valid From
+          </small>
+          <div>
+            
+          </div>
+        </div>
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Valid To
+          </small>
+          <div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="col-sm-12 col-lg-4 mb-2 mb-lg-0"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Unassigned Codes
+          </small>
+          <div>
+            0
+          </div>
+        </div>
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Enrollments Redeemed
+          </small>
+          <div>
+            0 of 1
+            <span
+              className="ml-1"
+            >
+              (0%)
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="icons col-lg-1 order-first order-lg-last text-right pr-2 mt-1 m-lg-0"
+    >
+      <span
+        aria-hidden={true}
+        className="fa fa-chevron-down text-primary"
+        id="Icon1"
+      />
+      <span
+        className="sr-only"
+      >
+        Open coupon details
+      </span>
+    </div>
+  </div>
+  <div
+    className="coupon-details row no-gutters px-2 my-3 d-none"
+    id="coupon-details-1"
+  >
+    <div
+      className="col"
+    />
+  </div>
+</div>
+`;
+
+exports[`<Coupon /> renders correctly without max uses 1`] = `
+<div
+  className="coupon mb-3 mb-lg-2 rounded border"
+>
+  <div
+    aria-controls="coupon-details-1"
+    aria-expanded={false}
+    className="metadata row no-gutters p-2 d-flex align-items-center rounded"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <div
+      className="col-sm-12 col-lg-3 mb-2 mb-lg-0"
+    >
+      <small
+        className="text-muted"
+      >
+        Coupon Name
+      </small>
+      <div>
+        Test Coupon
+      </div>
+    </div>
+    <div
+      className="col-sm-12 col-lg-4 mb-2 mb-lg-0"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Valid From
+          </small>
+          <div>
+            
+          </div>
+        </div>
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Valid To
+          </small>
+          <div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="col-sm-12 col-lg-4 mb-2 mb-lg-0"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Unassigned Codes
+          </small>
+          <div>
+            0
+          </div>
+        </div>
+        <div
+          className="col"
+        >
+          <small
+            className="text-muted"
+          >
+            Enrollments Redeemed
+          </small>
+          <div>
+            0
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="icons col-lg-1 order-first order-lg-last text-right pr-2 mt-1 m-lg-0"
+    >
+      <span
+        aria-hidden={true}
+        className="fa fa-chevron-down text-primary"
+        id="Icon1"
+      />
+      <span
+        className="sr-only"
+      >
+        Open coupon details
+      </span>
+    </div>
+  </div>
+  <div
+    className="coupon-details row no-gutters px-2 my-3 d-none"
+    id="coupon-details-1"
+  >
+    <div
+      className="col"
+    />
+  </div>
+</div>
+`;

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -5,7 +5,7 @@ import { Icon } from '@edx/paragon';
 
 import CouponDetails from '../../containers/CouponDetails';
 
-import { isTriggerKey } from '../../utils';
+import { isTriggerKey, formatTimestamp } from '../../utils';
 
 import './Coupon.scss';
 
@@ -150,11 +150,15 @@ class Coupon extends React.Component {
             <div className="row no-gutters">
               <div className="col">
                 <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Valid From</small>
-                <div>{data.start_date}</div>
+                <div>
+                  {formatTimestamp({ timestamp: data.start_date })}
+                </div>
               </div>
               <div className="col">
                 <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Valid To</small>
-                <div>{data.end_date}</div>
+                <div>
+                  {formatTimestamp({ timestamp: data.end_date })}
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -88,6 +88,29 @@ class Coupon extends React.Component {
     );
   }
 
+  renderEnrollmentsRedeemed() {
+    const {
+      data: {
+        num_uses: numUses,
+        max_uses: maxUses,
+      },
+    } = this.props;
+
+    const text = maxUses ? `${numUses} of ${maxUses}` : numUses;
+    const children = [text];
+
+    if (maxUses) {
+      const percentUsed = Math.round((numUses / maxUses) * 100);
+      children.push((
+        <span className="ml-1">
+          {`(${percentUsed}%)`}
+        </span>
+      ));
+    }
+
+    return children;
+  }
+
   render() {
     const { detailsExpanded, dimmed } = this.state;
     const { data } = this.props;
@@ -98,7 +121,7 @@ class Coupon extends React.Component {
           'coupon mb-3 mb-lg-2 rounded border',
           {
             expanded: detailsExpanded,
-            'border-danger': data.hasError && !detailsExpanded,
+            'border-danger': data.has_error && !detailsExpanded,
             dimmed,
           },
         )}
@@ -127,11 +150,11 @@ class Coupon extends React.Component {
             <div className="row no-gutters">
               <div className="col">
                 <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Valid From</small>
-                <div>{data.validFromDate}</div>
+                <div>{data.start_date}</div>
               </div>
               <div className="col">
                 <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Valid To</small>
-                <div>{data.validToDate}</div>
+                <div>{data.end_date}</div>
               </div>
             </div>
           </div>
@@ -139,25 +162,22 @@ class Coupon extends React.Component {
             <div className="row no-gutters">
               <div className="col">
                 <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Unassigned Codes</small>
-                <div>{data.unassignedCodes}</div>
+                <div>{data.num_unassigned}</div>
               </div>
               <div className="col">
                 <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Enrollments Redeemed</small>
                 <div>
-                  {`${data.enrollmentsRedeemed} of ${data.totalEnrollments}`}
-                  <span className="ml-1">
-                    {`(${Math.round((data.enrollmentsRedeemed / data.totalEnrollments) * 100)}%)`}
-                  </span>
+                  {this.renderEnrollmentsRedeemed()}
                 </div>
               </div>
             </div>
           </div>
           <div className="icons col-lg-1 order-first order-lg-last text-right pr-2 mt-1 m-lg-0">
-            {data.hasError && !detailsExpanded && this.renderErrorIcon()}
+            {data.has_error && !detailsExpanded && this.renderErrorIcon()}
             {this.renderExpandCollapseIcon()}
           </div>
         </div>
-        {<CouponDetails id={data.id} expanded={detailsExpanded} hasError={data.hasError} />}
+        {<CouponDetails id={data.id} expanded={detailsExpanded} hasError={data.has_error} />}
       </div>
     );
   }
@@ -170,7 +190,14 @@ Coupon.defaultProps = {
 
 Coupon.propTypes = {
   data: PropTypes.shape({
-    // ...
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    start_date: PropTypes.string.isRequired,
+    end_date: PropTypes.string.isRequired,
+    has_error: PropTypes.bool.isRequired,
+    num_assigned: PropTypes.number.isRequired,
+    num_uses: PropTypes.number.isRequired,
+    max_uses: PropTypes.number,
   }).isRequired,
   onExpand: PropTypes.func,
   onCollapse: PropTypes.func,

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -102,7 +102,7 @@ class Coupon extends React.Component {
     if (maxUses) {
       const percentUsed = Math.round((numUses / maxUses) * 100);
       children.push((
-        <span className="ml-1">
+        <span key="percent-redemptions-used" className="ml-1">
           {`(${percentUsed}%)`}
         </span>
       ));
@@ -195,7 +195,7 @@ Coupon.propTypes = {
     start_date: PropTypes.string.isRequired,
     end_date: PropTypes.string.isRequired,
     has_error: PropTypes.bool.isRequired,
-    num_assigned: PropTypes.number.isRequired,
+    num_unassigned: PropTypes.number.isRequired,
     num_uses: PropTypes.number.isRequired,
     max_uses: PropTypes.number,
   }).isRequired,

--- a/src/demo/coupons.js
+++ b/src/demo/coupons.js
@@ -23,14 +23,14 @@ const coupons = {
     return {
       id: index,
       title: faker.random.words(),
-      validFromDate: formatTimestamp({ timestamp: validFromDate.toUTCString() }),
-      validToDate: formatTimestamp({
+      start_date: formatTimestamp({ timestamp: validFromDate.toUTCString() }),
+      end_date: formatTimestamp({
         timestamp: faker.date.future(null, validFromDate).toUTCString(),
       }),
-      unassignedCodes: faker.random.number({ min: 1, max: 20 }),
-      enrollmentsRedeemed: faker.random.number({ min: 1, max: totalEnrollments }),
-      totalEnrollments,
-      hasError: false,
+      num_unassigned: faker.random.number({ min: 1, max: 20 }),
+      num_uses: faker.random.number({ min: 1, max: totalEnrollments }),
+      max_uses: faker.random.boolean() ? totalEnrollments : null,
+      has_error: false,
     };
   }),
 };
@@ -60,6 +60,7 @@ const getCodes = (couponHasError = false) => {
       const codeHasError = couponHasError && index <= 1;
       const isAssigned = codeHasError || faker.random.boolean();
       const assignedTo = getAssignedTo(isAssigned);
+
       return {
         title: Math.random().toString(36).substring(2).toUpperCase(),
         assigned_to: assignedTo.name,
@@ -76,7 +77,7 @@ const getCodes = (couponHasError = false) => {
   };
 };
 
-coupons.results[0].hasError = firstCouponHasError;
+coupons.results[0].has_error = firstCouponHasError;
 
 export {
   coupons,

--- a/src/demo/coupons.js
+++ b/src/demo/coupons.js
@@ -1,6 +1,5 @@
 import faker from 'faker';
 
-import { formatTimestamp } from '../utils';
 import { configuration } from '../config';
 
 const couponsCount = 15;
@@ -23,10 +22,8 @@ const coupons = {
     return {
       id: index,
       title: faker.random.words(),
-      start_date: formatTimestamp({ timestamp: validFromDate.toUTCString() }),
-      end_date: formatTimestamp({
-        timestamp: faker.date.future(null, validFromDate).toUTCString(),
-      }),
+      start_date: validFromDate.toISOString(),
+      end_date: faker.date.future(null, validFromDate).toISOString(),
       num_unassigned: faker.random.number({ min: 1, max: 20 }),
       num_uses: faker.random.number({ min: 1, max: totalEnrollments }),
       max_uses: faker.random.boolean() ? totalEnrollments : null,

--- a/src/demo/rewireEcommerceApiService.js
+++ b/src/demo/rewireEcommerceApiService.js
@@ -2,7 +2,7 @@ import EcommerceApiService from '../../src/data/services/EcommerceApiService';
 
 import { codes, coupons } from './data';
 
-const firstCouponHasError = coupons.results[0].hasError;
+const firstCouponHasError = coupons.results[0].has_error;
 
 const findCouponIndexById = couponId =>
   coupons.results.findIndex(coupon => coupon.id === couponId);
@@ -13,7 +13,7 @@ const rewire = () => {
   });
 
   EcommerceApiService.fetchCouponDetails = couponId => Promise.resolve({
-    data: coupons.results[findCouponIndexById(couponId)].hasError ?
+    data: coupons.results[findCouponIndexById(couponId)].has_error ?
       codes(firstCouponHasError) : codes(),
   });
 };


### PR DESCRIPTION
Now that we have know the format of the coupon overview API response, we can update the field names in the `Coupon` component and demo data.

Also, after discussing with @brittneyexline and Jennifer about how the `max_uses` field can potentially be `null` (i.e., "unlimited" uses), the UI should only show "X of Y" in the "Enrollments Redeemed" column of the coupons if `max_uses` is set. If it isn't, we will only show `num_uses` field, e.g.:

![image](https://user-images.githubusercontent.com/2828721/48793913-71b27280-ecc6-11e8-9648-f0a1ccda0b00.png)
