### PR TITLE
Swap out filter buttons with dropdown select

### DIFF
--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -101,7 +101,7 @@ describe('<Coupon />', () => {
 
       simulateCouponClick();
       expect(mockOnExpand).toBeCalledTimes(1);
-      expect(wrapper.find(Coupon).find(CouponDetails).prop('expanded')).toBeTruthy();
+      expect(wrapper.find(Coupon).find(CouponDetails).prop('isExpanded')).toBeTruthy();
     });
 
     it('collapses on click of expanded coupon', () => {
@@ -113,11 +113,11 @@ describe('<Coupon />', () => {
       ));
 
       simulateCouponClick();
-      expect(wrapper.find(Coupon).find(CouponDetails).prop('expanded')).toBeTruthy();
+      expect(wrapper.find(Coupon).find(CouponDetails).prop('isExpanded')).toBeTruthy();
 
       simulateCouponClick();
       expect(mockOnCollapse).toBeCalledTimes(1);
-      expect(wrapper.find(Coupon).find(CouponDetails).prop('expanded')).toBeFalsy();
+      expect(wrapper.find(Coupon).find(CouponDetails).prop('isExpanded')).toBeFalsy();
     });
   });
 });

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -19,7 +19,7 @@ class Coupon extends React.Component {
     super(props);
 
     this.state = {
-      detailsExpanded: false,
+      isExpanded: false,
       dimmed: false,
     };
 
@@ -35,20 +35,20 @@ class Coupon extends React.Component {
 
   closeCouponDetails() {
     this.setState({
-      detailsExpanded: false,
+      isExpanded: false,
       dimmed: false,
     });
   }
 
   toggleCouponDetails() {
-    const detailsExpanded = !this.state.detailsExpanded;
+    const isExpanded = !this.state.isExpanded;
 
     this.setState({
-      detailsExpanded,
+      isExpanded,
       dimmed: false,
     });
 
-    if (detailsExpanded) {
+    if (isExpanded) {
       this.props.onExpand();
     } else {
       this.props.onCollapse();
@@ -56,21 +56,21 @@ class Coupon extends React.Component {
   }
 
   handleCouponKeyDown(event) {
-    const { detailsExpanded } = this.state;
-    if (!detailsExpanded && isTriggerKey({ triggerKeys, action: 'OPEN_DETAILS', key: event.key })) {
+    const { isExpanded } = this.state;
+    if (!isExpanded && isTriggerKey({ triggerKeys, action: 'OPEN_DETAILS', key: event.key })) {
       event.preventDefault();
       this.toggleCouponDetails();
-    } else if (detailsExpanded && isTriggerKey({ triggerKeys, action: 'CLOSE_DETAILS', key: event.key })) {
+    } else if (isExpanded && isTriggerKey({ triggerKeys, action: 'CLOSE_DETAILS', key: event.key })) {
       event.preventDefault();
       this.toggleCouponDetails();
     }
   }
 
   renderExpandCollapseIcon() {
-    const { detailsExpanded } = this.state;
-    const iconClass = detailsExpanded ? 'fa-chevron-up' : 'fa-chevron-down';
-    const iconColor = detailsExpanded ? 'text-white' : 'text-primary';
-    const screenReaderText = detailsExpanded ? 'Close' : 'Open';
+    const { isExpanded } = this.state;
+    const iconClass = isExpanded ? 'fa-chevron-up' : 'fa-chevron-down';
+    const iconColor = isExpanded ? 'text-white' : 'text-primary';
+    const screenReaderText = isExpanded ? 'Close' : 'Open';
     return (
       <Icon
         className={['fa', iconClass, iconColor]}
@@ -112,7 +112,7 @@ class Coupon extends React.Component {
   }
 
   render() {
-    const { detailsExpanded, dimmed } = this.state;
+    const { isExpanded, dimmed } = this.state;
     const { data } = this.props;
 
     return (
@@ -120,8 +120,8 @@ class Coupon extends React.Component {
         className={classNames(
           'coupon mb-3 mb-lg-2 rounded border',
           {
-            expanded: detailsExpanded,
-            'border-danger': data.has_error && !detailsExpanded,
+            expanded: isExpanded,
+            'border-danger': data.has_error && !isExpanded,
             dimmed,
           },
         )}
@@ -131,31 +131,31 @@ class Coupon extends React.Component {
             'metadata',
             'row no-gutters p-2 d-flex align-items-center',
             {
-              rounded: !detailsExpanded,
-              'rounded-top': detailsExpanded,
+              rounded: !isExpanded,
+              'rounded-top': isExpanded,
             },
           )}
           onClick={this.toggleCouponDetails}
           onKeyDown={this.handleCouponKeyDown}
           role="button"
           tabIndex="0"
-          aria-expanded={detailsExpanded}
+          aria-expanded={isExpanded}
           aria-controls={`coupon-details-${data.id}`}
         >
           <div className="col-sm-12 col-lg-3 mb-2 mb-lg-0">
-            <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Coupon Name</small>
+            <small className={classNames({ 'text-muted': !isExpanded, 'text-light': isExpanded })}>Coupon Name</small>
             <div>{data.title}</div>
           </div>
           <div className="col-sm-12 col-lg-4 mb-2 mb-lg-0">
             <div className="row no-gutters">
               <div className="col">
-                <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Valid From</small>
+                <small className={classNames({ 'text-muted': !isExpanded, 'text-light': isExpanded })}>Valid From</small>
                 <div>
                   {formatTimestamp({ timestamp: data.start_date })}
                 </div>
               </div>
               <div className="col">
-                <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Valid To</small>
+                <small className={classNames({ 'text-muted': !isExpanded, 'text-light': isExpanded })}>Valid To</small>
                 <div>
                   {formatTimestamp({ timestamp: data.end_date })}
                 </div>
@@ -165,11 +165,11 @@ class Coupon extends React.Component {
           <div className="col-sm-12 col-lg-4 mb-2 mb-lg-0">
             <div className="row no-gutters">
               <div className="col">
-                <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Unassigned Codes</small>
+                <small className={classNames({ 'text-muted': !isExpanded, 'text-light': isExpanded })}>Unassigned Codes</small>
                 <div>{data.num_unassigned}</div>
               </div>
               <div className="col">
-                <small className={classNames({ 'text-muted': !detailsExpanded, 'text-light': detailsExpanded })}>Enrollments Redeemed</small>
+                <small className={classNames({ 'text-muted': !isExpanded, 'text-light': isExpanded })}>Enrollments Redeemed</small>
                 <div>
                   {this.renderEnrollmentsRedeemed()}
                 </div>
@@ -177,11 +177,11 @@ class Coupon extends React.Component {
             </div>
           </div>
           <div className="icons col-lg-1 order-first order-lg-last text-right pr-2 mt-1 m-lg-0">
-            {data.has_error && !detailsExpanded && this.renderErrorIcon()}
+            {data.has_error && !isExpanded && this.renderErrorIcon()}
             {this.renderExpandCollapseIcon()}
           </div>
         </div>
-        {<CouponDetails id={data.id} expanded={detailsExpanded} hasError={data.has_error} />}
+        {<CouponDetails id={data.id} isExpanded={isExpanded} hasError={data.has_error} />}
       </div>
     );
   }

--- a/src/components/CouponDetails/CouponDetails.scss
+++ b/src/components/CouponDetails/CouponDetails.scss
@@ -37,6 +37,7 @@
         }
     }
     
+    .toggles,
     .bulk-actions {
         .form-group {
             display: inline-block;
@@ -44,6 +45,10 @@
             &,
             label {
                 margin: 0;
+            }
+
+            label {
+                font-weight: 600;
             }
         }
     }

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -17,31 +17,28 @@ class CouponDetails extends React.Component {
   constructor(props) {
     super(props);
 
-    this.tableColumns = [
-      {
-        label: <CheckBox />,
-        key: 'select',
-      },
-      {
-        label: 'Assigned To',
-        key: 'assigned_to',
-      },
-      {
-        label: 'Redemptions',
-        key: 'redemptions',
-      },
-      {
-        label: 'Code',
-        key: 'title',
-      },
-      {
-        label: 'Actions',
-        key: 'actions',
-      },
-    ];
+    this.defaultToggle = 'not-assigned';
 
     this.state = {
-      selectedToggle: 'not-assigned',
+      selectedToggle: this.defaultToggle,
+      tableColumns: [
+        {
+          label: <CheckBox />,
+          key: 'select',
+        },
+        {
+          label: 'Redemptions',
+          key: 'redemptions',
+        },
+        {
+          label: 'Code',
+          key: 'title',
+        },
+        {
+          label: 'Actions',
+          key: 'actions',
+        },
+      ],
     };
 
     this.toggleSelectRef = React.createRef();
@@ -94,11 +91,27 @@ class CouponDetails extends React.Component {
   }
 
   handleToggleSelect() {
+    const { tableColumns } = this.state;
     const ref = this.toggleSelectRef && this.toggleSelectRef.current;
+    const selectedToggle = ref && ref.state.value;
+    const assignedToColumnIndex = tableColumns.findIndex(column => column.key === 'assigned_to');
 
-    if (ref) {
+    if (selectedToggle !== this.defaultToggle && assignedToColumnIndex === -1) {
+      // Add assigned_to column if it doesn't already exist and
+      // the toggle is something other than "Not Assigned".
+      tableColumns.splice(1, 0, {
+        label: 'Assigned To',
+        key: 'assigned_to',
+      });
+    } else if (selectedToggle === this.defaultToggle && assignedToColumnIndex > -1) {
+      // Remove assigned_to column if it already exists and the toggle is "Not Assigned".
+      tableColumns.splice(assignedToColumnIndex, 1);
+    }
+
+    if (selectedToggle) {
       this.setState({
-        selectedToggle: ref.state.value,
+        selectedToggle,
+        tableColumns,
       });
     }
   }
@@ -129,7 +142,7 @@ class CouponDetails extends React.Component {
   }
 
   render() {
-    const { selectedToggle } = this.state;
+    const { selectedToggle, tableColumns } = this.state;
     const { id, hasError, isExpanded } = this.props;
 
     return (
@@ -216,7 +229,7 @@ class CouponDetails extends React.Component {
                 id="coupon-details"
                 className="coupon-details-table"
                 fetchMethod={() => EcommerceApiService.fetchCouponDetails(id)}
-                columns={this.tableColumns}
+                columns={tableColumns}
                 formatData={this.formatCouponData}
               />
             </React.Fragment>

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -41,16 +41,13 @@ class CouponDetails extends React.Component {
     ];
 
     this.state = {
-      selectedFilter: null,
+      selectedToggle: 'not-assigned',
     };
 
-    this.formatCouponData = this.formatCouponData.bind(this);
-  }
+    this.toggleSelectRef = React.createRef();
 
-  setSelectedFilter(selectedFilter) {
-    this.setState({
-      selectedFilter,
-    });
+    this.formatCouponData = this.formatCouponData.bind(this);
+    this.handleToggleSelect = this.handleToggleSelect.bind(this);
   }
 
   getActionButton(code) {
@@ -96,6 +93,16 @@ class CouponDetails extends React.Component {
     return !this.isTableLoading() && [hasError].some(item => item);
   }
 
+  handleToggleSelect() {
+    const ref = this.toggleSelectRef && this.toggleSelectRef.current;
+
+    if (ref) {
+      this.setState({
+        selectedToggle: ref.state.value,
+      });
+    }
+  }
+
   formatCouponData(data) {
     return data.map(code => ({
       ...code,
@@ -122,8 +129,8 @@ class CouponDetails extends React.Component {
   }
 
   render() {
-    const { selectedFilter } = this.state;
-    const { id, hasError, expanded } = this.props;
+    const { selectedToggle } = this.state;
+    const { id, hasError, isExpanded } = this.props;
 
     return (
       <div
@@ -131,12 +138,12 @@ class CouponDetails extends React.Component {
         className={classNames([
           'coupon-details row no-gutters px-2 my-3',
           {
-            'd-none': !expanded,
+            'd-none': !isExpanded,
           },
         ])}
       >
         <div className="col">
-          {expanded &&
+          {isExpanded &&
             <React.Fragment>
               <div className="details-header row no-gutters mb-3">
                 <div className="col-12 col-md-6 mb-2 mb-md-0">
@@ -151,37 +158,28 @@ class CouponDetails extends React.Component {
                 </div>
               </div>
               <div className="row mb-3">
-                <div className="filters col-12 col-md-8">
+                <div className="toggles col-12 col-md-8">
                   <div className="row">
                     <div className="col">
-                      <div className="mb-1">Filter:</div>
-                      <Button
-                        className={['btn-sm', 'mr-2']}
-                        buttonType={selectedFilter === 'not-assigned' ? 'primary' : 'outline-primary'}
-                        label="Not Assigned"
-                        onClick={() => this.setSelectedFilter('not-assigned')}
+                      <InputSelect
+                        ref={this.toggleSelectRef}
+                        className={['mt-1']}
+                        name="table-view"
+                        label="Table View:"
+                        value={selectedToggle}
+                        options={[
+                          { label: 'Not Assigned', value: 'not-assigned' },
+                          { label: 'Not Redeemed', value: 'not-redeemed' },
+                        ]}
                         disabled={this.isTableLoading()}
                       />
                       <Button
-                        className={['btn-sm']}
-                        buttonType={selectedFilter === 'not-redeemed' ? 'primary' : 'outline-primary'}
-                        label="Not Redeemed"
-                        onClick={() => this.setSelectedFilter('not-redeemed')}
+                        className={['ml-2']}
+                        buttonType="primary"
+                        label="Go"
+                        onClick={this.handleToggleSelect}
                         disabled={this.isTableLoading()}
                       />
-                      {selectedFilter &&
-                        <Button
-                          className={['btn-sm', 'ml-2']}
-                          buttonType="outline-secondary"
-                          label={
-                            <React.Fragment>
-                              <Icon className={['fa', 'fa-close', 'mr-1']} />
-                              Clear filters
-                            </React.Fragment>
-                          }
-                          onClick={() => this.setSelectedFilter(null)}
-                        />
-                      }
                     </div>
                   </div>
                 </div>
@@ -230,14 +228,14 @@ class CouponDetails extends React.Component {
 }
 
 CouponDetails.defaultProps = {
-  expanded: false,
+  isExpanded: false,
   hasError: false,
   couponDetailsTable: {},
 };
 
 CouponDetails.propTypes = {
   id: PropTypes.number.isRequired,
-  expanded: PropTypes.bool,
+  isExpanded: PropTypes.bool,
   hasError: PropTypes.bool,
   couponDetailsTable: PropTypes.shape({}),
 };


### PR DESCRIPTION
This PR removes the previous filter buttons and, in their place, puts in an `InputSelect` component. I also rename a few variables/props to be `isExpanded`. This PR should be probably be merged before @mushtaqak's WIP PR lands as the filter UI has changed here.

![image](https://user-images.githubusercontent.com/2828721/49667348-bf4e0f80-fa28-11e8-8983-db9b4ebbcfc4.png)