### PR TITLE
Fix sidebar shouldInclude logic to use hidden instead

### DIFF
--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -24,9 +24,9 @@ class Sidebar extends React.Component {
         title: 'Code Management',
         to: `${baseUrl}/admin/codes`,
         iconClassName: 'fa-tags',
-        // TODO we can also use `shouldInclude` when determining whether to show the
+        // TODO we can also use `hidden` when determining whether to show the
         // Code Management link in the sidebar navigation depending on the enterprise customer.
-        shouldInclude: features.CODE_MANAGEMENT,
+        hidden: !features.CODE_MANAGEMENT,
       },
     ];
 
@@ -110,7 +110,7 @@ class Sidebar extends React.Component {
       >
         <div className="sidebar-content py-2">
           <ul className="list-unstyled m-0">
-            {this.menuItems.filter(item => item.shouldInclude !== false).map(item => (
+            {this.menuItems.filter(item => !item.hidden).map(item => (
               <li key={item.to} className="rounded-0">
                 <IconLink
                   {...item}

--- a/src/containers/Sidebar/Sidebar.test.jsx
+++ b/src/containers/Sidebar/Sidebar.test.jsx
@@ -9,10 +9,14 @@ import { Provider } from 'react-redux';
 
 import Sidebar from './index';
 
+import { features } from '../../config';
+
 import {
   EXPAND_SIDEBAR,
   COLLAPSE_SIDEBAR,
 } from '../../data/constants/sidebar';
+
+features.CODE_MANAGEMENT = true;
 
 const mockStore = configureMockStore([thunk]);
 const initialState = {


### PR DESCRIPTION
Before, we were filtering out the sidebar menu items where `shouldInclude` is explicitly `false`. However, this results in the "Code Management" link still appearing in the sidebar on stage after merging the original sidebar navigation PR.

This PR swaps out `shouldInclude` for `hidden`, filtering out menu items for which `hidden` is truthy.