### PR TITLE
Fix public support page.

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -13,7 +13,9 @@ import './Header.scss';
 
 class Header extends React.Component {
   componentDidMount() {
-    this.props.fetchUserProfile(this.props.username);
+    if (this.props.username) {
+      this.props.fetchUserProfile(this.props.username);
+    }
   }
 
   getProfileIconElement() {

--- a/src/containers/Header/Header.test.jsx
+++ b/src/containers/Header/Header.test.jsx
@@ -5,7 +5,9 @@ import { MemoryRouter } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
+import { mount } from 'enzyme';
 
+import apiClient from '../../data/apiClient';
 import Header from './index';
 import EdxLogo from '../../images/edx-logo.png';
 
@@ -112,6 +114,35 @@ describe('<Header />', () => {
       ))
       .toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('does not render profile image or dropdown if unauthenticated', () => {
+    store = mockStore({
+      portalConfiguration: {},
+      authentication: {},
+      userProfile: {},
+      sidebar: {},
+    });
+    tree = renderer
+      .create((
+        <HeaderWrapper store={store} />
+      ))
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('does not call getUserProfile if not authenticated', () => {
+    store = mockStore({
+      portalConfiguration: {},
+      authentication: {},
+      userProfile: {},
+      sidebar: {},
+    });
+    const getUserProfileMock = jest.fn();
+    apiClient.getUserProfile = getUserProfileMock;
+
+    mount(<HeaderWrapper store={store} />);
+    expect(getUserProfileMock.mock.calls.length).toBe(0);
   });
 
   describe('renders sidebar toggle correctly', () => {

--- a/src/containers/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/containers/Header/__snapshots__/Header.test.jsx.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Header /> does not render profile image or dropdown if unauthenticated 1`] = `
+<header
+  className="container-fluid"
+>
+  <nav
+    className="navbar px-0 justify-content-between"
+  >
+    <div>
+      <a
+        className="navbar-brand"
+        href="/"
+        onClick={[Function]}
+      >
+        <img
+          alt="edX logo"
+          onError={[Function]}
+          src="test-file-stub"
+        />
+      </a>
+      <span
+        className="badge badge-secondary beta"
+      >
+        Beta
+      </span>
+    </div>
+  </nav>
+</header>
+`;
+
 exports[`<Header /> renders default profile image correctly 1`] = `
 <header
   className="container-fluid"


### PR DESCRIPTION
We were attempting to make an unauthenticated user profile API call on render of the Header under the public support route causing a redirect to the login page. 

This can be tested here: https://portal.edxdev.org/public/support