### PR TITLE
Add url for ecommerce IDA to dev webpack config

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -109,7 +109,7 @@ module.exports = Merge.smart(commonConfig, {
       CSRF_TOKEN_API_PATH: '/csrf/api/v1/token',
       REFRESH_ACCESS_TOKEN_ENDPOINT: 'http://localhost:18000/login',
       DATA_API_BASE_URL: 'http://localhost:8000',
-      ECOMMERCE_API_BASE_URL: null,
+      ECOMMERCE_API_BASE_URL: 'http://localhost:18130',
       SEGMENT_KEY: null,
       ACCESS_TOKEN_COOKIE_NAME: 'edx-jwt-cookie-header-payload',
       USER_INFO_COOKIE_NAME: 'edx-user-info',

--- a/src/data/services/EcommerceApiService.js
+++ b/src/data/services/EcommerceApiService.js
@@ -15,7 +15,7 @@ class EcommerceApiService {
       ...options,
     };
 
-    const url = `${EcommerceApiService.ecommerceBaseUrl}/enterprise/coupons/${enterpriseId}/overview/?${qs.stringify(queryParams)}`;
+    const url = `${EcommerceApiService.ecommerceBaseUrl}/api/v2/enterprise/coupons/${enterpriseId}/overview/?${qs.stringify(queryParams)}`;
     return apiClient.get(url);
   }
 
@@ -27,7 +27,7 @@ class EcommerceApiService {
       ...options,
     };
 
-    const url = `${EcommerceApiService.ecommerceBaseUrl}/enterprise/coupons/${couponId}/${endpoint}/?${qs.stringify(queryParams)}`;
+    const url = `${EcommerceApiService.ecommerceBaseUrl}/api/v2/enterprise/coupons/${couponId}/${endpoint}/?${qs.stringify(queryParams)}`;
     return apiClient.get(url);
   }
 


### PR DESCRIPTION
Currently, our `webpack.dev.config.js` file does not include the URL for the ecommerce IDA. This PR adds the URL to the webpack config and updates the URLs used in our `EcommerceServiceApi.js` file.