### PR TITLE
ENT-1455: Remove Unneeded Error Handling

### DIFF
--- a/src/data/actions/table.js
+++ b/src/data/actions/table.js
@@ -70,12 +70,6 @@ const paginateTable = (tableId, fetchMethod, pageNumber) => (
       dispatch(paginationSuccess(tableId, response.data, options.ordering));
     }).catch((error) => {
       NewRelicService.logAPIErrorResponse(error);
-      // This endpoint returns a 404 if no data exists,
-      // so we convert it to an empty response here.
-      if (error.response.status === 404) {
-        dispatch(paginationSuccess(tableId, { results: [] }, options.ordering));
-        return;
-      }
       dispatch(paginationFailure(tableId, error));
     });
   }


### PR DESCRIPTION
- The ```/enterprise/api/v0/enterprise/<enterprise_uuid>/enrollments```
  api used to return 404 if there were no enrollments for that
  enterprise.  So, the front-end code had to catch that error and
  display an empty list.
- That error handling is no longer necessary because the api returns an
  empty list now. (https://github.com/edx/edx-enterprise-data/pull/106)