### PR TITLE
Fix selected toggles demo data 

### DIFF
--- a/src/demo/coupons.js
+++ b/src/demo/coupons.js
@@ -5,7 +5,7 @@ import { configuration } from '../config';
 const couponsCount = 15;
 const codesCount = 65;
 
-const minRedemptionsCount = 0;
+const minRedemptionsCount = 1;
 const maxRedemptionsCount = 5;
 
 let firstCouponHasError = false;
@@ -15,7 +15,7 @@ if (configuration.NODE_ENV === 'development') {
   firstCouponHasError = true;
 }
 
-// Coupon details filter.
+// Coupon details filters.
 const unassignedCodesFilter = 'unassigned';
 const unredeemedCodesFilter = 'unredeemed';
 const partiallyRedeemedCodesFilter = 'partially-redeemed';
@@ -99,9 +99,9 @@ const getAllCodes = (couponHasError = false) => [...Array(codesCount)].map((_, i
 
   const maxUsed = maxRedemptionsCount - redemptionsAvailablePerCode;
   const redemptionsUsedPerCode = isAssigned ? faker.random.number({
-    min: minRedemptionsCount + 1,
-    max: codeHasError ? redemptionsAvailablePerCode : maxUsed,
-  }) : minRedemptionsCount;
+    min: minRedemptionsCount,
+    max: codeHasError ? maxUsed : redemptionsAvailablePerCode,
+  }) : faker.random.number({ min: minRedemptionsCount - 1, max: minRedemptionsCount });
 
   const errorMessage = `Unable to deliver email to ${assignedTo.name} (${assignedTo.email})`;
   return {
@@ -119,18 +119,17 @@ const getAllCodes = (couponHasError = false) => [...Array(codesCount)].map((_, i
 const allCodes = getAllCodes();
 
 const unassignedCodes = allCodes.filter(code => (
-  code.redemptions.available > minRedemptionsCount && code.redemptions.used < maxRedemptionsCount
+  code.assigned_to === undefined && code.redemptions.used < code.redemptions.available
 ));
 const unredeemedCodes = allCodes.filter(code => (
-  (code.redemptions.available === minRedemptionsCount &&
-    code.redemptions.used > minRedemptionsCount && code.redemptions.used < maxRedemptionsCount)
+  code.assigned_to !== undefined && code.redemptions.used < code.redemptions.available
 ));
 const partiallyRedeemedCodes = allCodes.filter(code => (
-  code.redemptions.available > minRedemptionsCount && code.redemptions.used > minRedemptionsCount
+  (code.redemptions.used >= minRedemptionsCount &&
+    code.redemptions.used < code.redemptions.available)
 ));
 const redeemedCodes = allCodes.filter(code => (
-  (code.redemptions.available === minRedemptionsCount &&
-    code.redemptions.used === minRedemptionsCount)
+  code.redemptions.available === code.redemptions.used
 ));
 
 const getCodes = ({ codeFilter = unassignedCodesFilter, couponHasError = false }) => {

--- a/src/demo/coupons.js
+++ b/src/demo/coupons.js
@@ -3,7 +3,7 @@ import faker from 'faker';
 import { configuration } from '../config';
 
 const couponsCount = 15;
-const codesCount = 65;
+const codesCount = 115;
 
 const minRedemptionsCount = 1;
 const maxRedemptionsCount = 5;
@@ -101,7 +101,7 @@ const getAllCodes = (couponHasError = false) => [...Array(codesCount)].map((_, i
   const redemptionsUsedPerCode = isAssigned ? faker.random.number({
     min: minRedemptionsCount,
     max: codeHasError ? maxUsed : redemptionsAvailablePerCode,
-  }) : faker.random.number({ min: minRedemptionsCount - 1, max: minRedemptionsCount });
+  }) : minRedemptionsCount - 1;
 
   const errorMessage = `Unable to deliver email to ${assignedTo.name} (${assignedTo.email})`;
   return {
@@ -125,7 +125,7 @@ const unredeemedCodes = allCodes.filter(code => (
   code.assigned_to !== undefined && code.redemptions.used < code.redemptions.available
 ));
 const partiallyRedeemedCodes = allCodes.filter(code => (
-  (code.redemptions.used >= minRedemptionsCount &&
+  (code.redemptions.used > minRedemptionsCount &&
     code.redemptions.used < code.redemptions.available)
 ));
 const redeemedCodes = allCodes.filter(code => (


### PR DESCRIPTION
This PR fixes a miner bug where we get `used > available`  redemptions(screenshot below)

![demo data - used available](https://user-images.githubusercontent.com/6991154/52055612-dc392780-252d-11e9-86d5-b87456b6081b.png)

This also modifies filters data such that data resembles data returned by backend api.

Below is short description for modified filters in demo data:

**Unassigned**: Codes with assignedTo ket as `undefined`.
**Unredeemed**: Assigned codes with assignedTo key set.
**Partially redeemed**: Codes with at-least one redemption but not completely redeemed (there is no 
 way in frontend to determine from the `used` key if a code was redeemed or assigned.)
**Redeemed**: Codes with `used === available`.

[ENT-1471](https://openedx.atlassian.net/browse/ENT-1471)