### PR TITLE
Updating CouponDetails selection logic to handle select all

### DIFF
--- a/src/components/CouponDetails/CouponDetails.scss
+++ b/src/components/CouponDetails/CouponDetails.scss
@@ -44,6 +44,46 @@
                 box-shadow: $btn-focus-box-shadow;
             }
         }
+
+        .form-check {
+            padding-left: 0;
+
+            input[type=checkbox] {
+                border: 0;
+                clip: rect(0 0 0 0);
+                height: 1px;
+                margin: -1px;
+                overflow: hidden;
+                padding: 0;
+                position: absolute;
+                width: 1px;
+
+                & + label {
+                    width: 15px;
+
+                    &:before {
+                        font-family: FontAwesome;
+                        content: "\f096"; /* fa-square-o */
+                        font-weight: normal;
+                        font-size: 1rem;
+                        line-height: 1rem;
+                    }
+                }
+    
+                &:checked + label:before {
+                    content: "\f046"; /* fa-check-square-o */
+                }
+
+                &.mixed + label:before {
+                    content: "\f146"; /* fa-minus-square */
+                }
+    
+                &:focus + label:before {
+                    border-radius: 2px;
+                    box-shadow: $input-btn-focus-box-shadow;
+                }
+            }
+        }
     }
     
     .toggles,

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -316,6 +316,9 @@ class CouponDetails extends React.Component {
       tableColumns,
       selectedToggle: value,
       selectedCodes: [],
+      hasAllCodesSelected: false,
+    }, () => {
+      this.updateSelectAllCheckBox();
     });
   }
 
@@ -331,7 +334,7 @@ class CouponDetails extends React.Component {
     const { selectedCodes, tableColumns } = this.state;
     const { couponDetailsTable: { data: tableData } } = this.props;
 
-    const allCodesForPageSelected = selectedCodes.length === tableData.results.length;
+    const allCodesForPageSelected = tableData && selectedCodes.length === tableData.results.length;
     const hasPartialSelection = selectedCodes.length > 0 && !allCodesForPageSelected;
 
     const selectColumn = tableColumns.shift();
@@ -346,7 +349,10 @@ class CouponDetails extends React.Component {
     // attribute appropriately.
     //
     // TODO: We may want to update Paragon `CheckBox` component to handle mixed state.
-    const selectAllCheckBoxDOM = document.getElementById(selectColumn.label.ref.current.state.id);
+    const selectAllCheckBoxRef = selectColumn.label.ref && selectColumn.label.ref.current;
+    const selectAllCheckBoxDOM = (
+      selectAllCheckBoxRef && document.getElementById(selectAllCheckBoxRef.state.id)
+    );
 
     if (selectAllCheckBoxDOM && hasPartialSelection) {
       selectAllCheckBoxDOM.setAttribute('aria-checked', 'mixed');

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -373,7 +373,7 @@ class CouponDetails extends React.Component {
       selectedCodes = [...selectedCodes, code];
     } else {
       // Remove code from selected codes array
-      selectedCodes = selectedCodes.filter(selectedCode => selectedCode.code !== code.code);
+      selectedCodes = selectedCodes.filter(selectedCode => selectedCode !== code);
       hasAllCodesSelected = false;
     }
 

--- a/src/containers/CodeAssignmentModal/CodeAssignmentModal.test.jsx
+++ b/src/containers/CodeAssignmentModal/CodeAssignmentModal.test.jsx
@@ -9,12 +9,22 @@ import { mount } from 'enzyme';
 import CodeAssignmentModal from './index';
 
 const mockStore = configureMockStore([thunk]);
-const initialState = {};
+const initialState = {
+  table: {
+    'coupon-details': {
+      data: {
+        count: 0,
+        results: [],
+      },
+    },
+  },
+};
 
 const CodeAssignmentModalWrapper = props => (
   <MemoryRouter>
     <Provider store={props.store}>
       <CodeAssignmentModal
+        couponId={1}
         title="AABBCC"
         onClose={() => {}}
         onSuccess={() => {}}

--- a/src/containers/CodeAssignmentModal/index.jsx
+++ b/src/containers/CodeAssignmentModal/index.jsx
@@ -4,6 +4,10 @@ import CodeAssignmentModal from '../../components/CodeAssignmentModal';
 
 import sendCodeAssignment from '../../data/actions/codeAssignment';
 
+const mapStateToProps = state => ({
+  couponDetailsTable: state.table['coupon-details'],
+});
+
 const mapDispatchToProps = dispatch => ({
   sendCodeAssignment: (couponId, options) => new Promise((resolve, reject) => {
     dispatch(sendCodeAssignment({
@@ -15,4 +19,4 @@ const mapDispatchToProps = dispatch => ({
   }),
 });
 
-export default connect(null, mapDispatchToProps)(CodeAssignmentModal);
+export default connect(mapStateToProps, mapDispatchToProps)(CodeAssignmentModal);

--- a/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
+++ b/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
@@ -804,7 +804,7 @@ exports[`CouponDetailsWrapper renders with table data 1`] = `
               aria-relevant="text"
               className="sr-only"
             >
-              Page 1, Current Page, of 1
+              Page 1, Current Page, of 2
             </div>
             <ul
               className="pagination"
@@ -833,16 +833,15 @@ exports[`CouponDetailsWrapper renders with table data 1`] = `
                 </button>
               </li>
               <li
-                className="page-item disabled"
+                className="page-item"
               >
                 <button
-                  aria-label="Next"
+                  aria-label="Next, Page 2"
                   className="btn next page-link"
-                  disabled={true}
+                  disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
-                  tabIndex="-1"
                   type="button"
                 >
                   <div>


### PR DESCRIPTION
This PR updates the code selection logic to better handle the selection of individual codes as well as selecting all codes through the "select all" checkbox in the table header.

If there are more codes than shown on the page, a status alert is shown, prompting the user to select all codes across all pages.

The `CodeAssignmentModal` component is updated to handle when codes across all pages are selected.

If codes are selected on a page, but not all of them, a partial "select all" checkbox is displayed, as seen below.

**UI Example of Selection Checkboxes**
![image](https://user-images.githubusercontent.com/2828721/52304085-d1342c00-295f-11e9-875d-4cfb366ab2e8.png)

![image 2](https://user-images.githubusercontent.com/2828721/52306358-b82e7980-2965-11e9-94c1-394f9aebf4ab.png)

![pasted_image_at_2019-02-05__4_46_pm](https://user-images.githubusercontent.com/2828721/52306356-b82e7980-2965-11e9-961f-ff5b2e724c90.png)
