### PR TITLE
Ensure bulk assign modal supports 0 unassigned codes

### DIFF
--- a/src/components/CodeAssignmentModal/index.jsx
+++ b/src/components/CodeAssignmentModal/index.jsx
@@ -182,6 +182,11 @@ class CodeAssignmentModal extends React.Component {
     /* eslint-enable no-underscore-dangle */
   }
 
+  hasBulkAssignData() {
+    const { data } = this.props;
+    return ['unassignedCodes', 'selectedCodes'].every(key => key in data);
+  }
+
   hasIndividualAssignData() {
     const { data } = this.props;
     return ['code', 'remainingUses'].every(key => key in data);
@@ -236,7 +241,7 @@ class CodeAssignmentModal extends React.Component {
       <React.Fragment>
         {submitFailed && this.renderErrorMessage()}
         <div className="assignment-details mb-4">
-          {isBulkAssign && data.unassignedCodes && (
+          {isBulkAssign && this.hasBulkAssignData() && (
             <React.Fragment>
               <p>Unassigned Codes: {data.unassignedCodes}</p>
               {data.selectedCodes.length > 0 && <p>Selected Codes: {data.selectedCodes.length}</p>}


### PR DESCRIPTION
[ENT-1525](https://openedx.atlassian.net/browse/ENT-1525)

Fixes the bulk version of `CodeAssignmentModal` to support 0 unassigned codes.

![image](https://user-images.githubusercontent.com/2828721/52352124-08efb200-29fa-11e9-8557-59e439c4e5cd.png)
