### PR TITLE
Increase modal width

### DIFF
--- a/src/components/CodeAssignmentModal/CodeAssignmentModal.scss
+++ b/src/components/CodeAssignmentModal/CodeAssignmentModal.scss
@@ -1,4 +1,8 @@
 .modal {
+    .modal-dialog {
+        max-width: 650px;
+    }
+
     .modal-title {
         span {
             font-weight: 600;


### PR DESCRIPTION
Increases the `max-width` property of the modal so it doesn't appear as narrow/congested. Prior to this change, the `max-width` was 500px. Here, we're increasing the modal width by 150px.