### PR TITLE
Disable assign bulk action for coupons with 0 unassigned codes

### DIFF
--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -87,6 +87,7 @@ class CouponDetails extends React.Component {
 
   getBulkActionSelectOptions() {
     const { selectedToggle } = this.state;
+    const { unassignedCodes } = this.props;
 
     const isAssignView = selectedToggle === 'unassigned';
     const isRedeemedView = selectedToggle === 'redeemed';
@@ -94,7 +95,7 @@ class CouponDetails extends React.Component {
     return [{
       label: 'Assign',
       value: 'assign',
-      disabled: !isAssignView || isRedeemedView,
+      disabled: !isAssignView || isRedeemedView || unassignedCodes === 0,
     }, {
       label: 'Remind',
       value: 'remind',
@@ -490,8 +491,6 @@ class CouponDetails extends React.Component {
       couponDetailsTable: { data: tableData },
     } = this.props;
 
-    const bulkActionSelectOptions = this.getBulkActionSelectOptions();
-
     return (
       <div
         id={`coupon-details-${id}`}
@@ -543,7 +542,7 @@ class CouponDetails extends React.Component {
                     name="bulk-action"
                     label="Bulk Action:"
                     value={this.getBulkActionSelectValue()}
-                    options={bulkActionSelectOptions}
+                    options={this.getBulkActionSelectOptions()}
                     disabled={this.isBulkAssignSelectDisabled()}
                   />
                   <Button
@@ -646,6 +645,7 @@ CouponDetails.defaultProps = {
 
 CouponDetails.propTypes = {
   id: PropTypes.number.isRequired,
+  unassignedCodes: PropTypes.number.isRequired,
   isExpanded: PropTypes.bool,
   hasError: PropTypes.bool,
   couponDetailsTable: PropTypes.shape({}),

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -25,6 +25,7 @@ const CouponDetailsWrapper = props => (
       <CouponDetails
         id={1}
         couponTitle="test-title"
+        unassignedCodes={10}
         {...props}
       />
     </Provider>


### PR DESCRIPTION
[ENT-1530](https://openedx.atlassian.net/browse/ENT-1530)

For coupons that have 0 unassigned codes, we should disable the bulk assign action in the input select as there are no codes to assign.