### PR TITLE
Minor updates to bulk remind

### DIFF
--- a/src/components/CodeReminderModal/index.jsx
+++ b/src/components/CodeReminderModal/index.jsx
@@ -52,8 +52,7 @@ class CodeReminderModal extends React.Component {
 
   validateFormData(formData) {
     const emailTemplateKey = 'email-template';
-
-    let errors = {}; // eslint-disable-line prefer-const
+    const errors = {};
 
     /* eslint-disable no-underscore-dangle */
     if (!formData[emailTemplateKey]) {
@@ -81,6 +80,11 @@ class CodeReminderModal extends React.Component {
       sendCodeReminder,
     } = this.props;
 
+    /* eslint-disable no-underscore-dangle */
+    const errors = {
+      _error: [],
+    };
+
     // Validate form data
     this.validateFormData(formData);
 
@@ -90,6 +94,11 @@ class CodeReminderModal extends React.Component {
     };
 
     if (isBulkRemind) {
+      if (!data.selectedCodes.length) {
+        errors._error.push('At least one code must be selected.');
+        throw new SubmissionError(errors);
+      }
+
       options.assignments = data.selectedCodes.map(code => ({
         email: code.assigned_to,
         code: code.code,
@@ -106,6 +115,7 @@ class CodeReminderModal extends React.Component {
           _error: [error.message],
         });
       });
+    /* eslint-enable no-underscore-dangle */
   }
 
   renderBody() {
@@ -127,7 +137,7 @@ class CodeReminderModal extends React.Component {
           )}
           {isBulkRemind && data.selectedCodes && (
             <React.Fragment>
-              {data.selectedCodes.length > 0 && <p>Selected Codes: {data.selectedCodes.length}</p>}
+              {data.selectedCodes.length > 0 && <p className="bulk-selected-codes">Selected Codes: {data.selectedCodes.length}</p>}
             </React.Fragment>
           )}
         </div>

--- a/src/components/CodeRevokeModal/emailTemplate.js
+++ b/src/components/CodeRevokeModal/emailTemplate.js
@@ -1,4 +1,5 @@
 const emailTemplate = `Your learning manager has revoked {CODE} and it is no longer assigned to your edX account {USER_EMAIL}.
+
 Please reach out to your Learning Manager for additional questions.`;
 
 export default emailTemplate;

--- a/src/components/CodeRevokeModal/index.jsx
+++ b/src/components/CodeRevokeModal/index.jsx
@@ -96,7 +96,7 @@ class CodeRevokeModal extends React.Component {
 
     if (isBulkRevoke) {
       if (!data.selectedCodes.length) {
-        errors._error.push('No code is selected.');
+        errors._error.push('At least one code must be selected.');
         throw new SubmissionError(errors);
       }
 

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -93,7 +93,7 @@ class CouponDetails extends React.Component {
   }
 
   getBulkActionSelectOptions() {
-    const { selectedToggle } = this.state;
+    const { selectedToggle, selectedCodes } = this.state;
     const { unassignedCodes } = this.props;
 
     const isAssignView = selectedToggle === 'unassigned';
@@ -106,11 +106,11 @@ class CouponDetails extends React.Component {
     }, {
       label: 'Remind',
       value: 'remind',
-      disabled: isAssignView || isRedeemedView,
+      disabled: isAssignView || isRedeemedView || selectedCodes.length === 0,
     }, {
       label: 'Revoke',
       value: 'revoke',
-      disabled: isAssignView || isRedeemedView,
+      disabled: isAssignView || isRedeemedView || selectedCodes.length === 0,
     }];
   }
 

--- a/src/containers/CodeReminderModal/CodeReminderModal.test.jsx
+++ b/src/containers/CodeReminderModal/CodeReminderModal.test.jsx
@@ -7,14 +7,30 @@ import thunk from 'redux-thunk';
 import { mount } from 'enzyme';
 
 import CodeReminderModal from './index';
+import EcommerceApiService from '../../data/services/EcommerceApiService';
+import emailTemplate from '../../components/CodeReminderModal/emailTemplate';
 
 const mockStore = configureMockStore([thunk]);
 const initialState = {};
+const couponId = 1;
+const data = {
+  code: 'ABC101',
+  assigned_to: 'edx@example.com',
+};
+
+const codeReminderRequestData = (numCodes) => {
+  const assignment = { code: `${data.code}`, email: `${data.assigned_to}` };
+  return {
+    assignments: Array(numCodes).fill(assignment),
+    template: emailTemplate,
+  };
+};
 
 const CodeReminderModalWrapper = props => (
   <MemoryRouter>
     <Provider store={props.store}>
       <CodeReminderModal
+        couponId={couponId}
         title="AABBCC"
         onClose={() => {}}
         onSuccess={() => {}}
@@ -33,13 +49,43 @@ CodeReminderModalWrapper.propTypes = {
 };
 
 describe('CodeReminderModalWrapper', () => {
-  it('renders individual assignment reminder modal', () => {
+  let spy;
+
+  afterEach(() => {
+    if (spy) {
+      spy.mockRestore();
+    }
+  });
+
+  it('renders individual reminder modal', () => {
     const wrapper = mount(<CodeReminderModalWrapper />);
     expect(wrapper.find('.assignment-detail').find('p')).toBeTruthy();
   });
 
-  it('renders bulk assignment reminder modal', () => {
-    const wrapper = mount(<CodeReminderModalWrapper isBulkRemind />);
+  it('renders bulk reminder modal', () => {
+    spy = jest.spyOn(EcommerceApiService, 'sendCodeReminder');
+    const codeRemindData = [data, data];
+    const wrapper = mount(<CodeReminderModalWrapper
+      data={{ ...codeRemindData, selectedCodes: codeRemindData }}
+      isBulkRemind
+    />);
+
+    expect(wrapper.find('.bulk-selected-codes').text()).toEqual('Selected Codes: 2');
     expect(wrapper.find('#email-template')).toBeTruthy();
+    wrapper.find('.modal-footer .btn-primary').simulate('click');
+    expect(spy).toHaveBeenCalledWith(couponId, codeReminderRequestData(2));
+  });
+
+  it('throws error if no code is selected for bulk remind', () => {
+    spy = jest.spyOn(EcommerceApiService, 'sendCodeReminder');
+    const codeReminderData = [data, data];
+    const wrapper = mount(<CodeReminderModalWrapper
+      data={{ ...codeReminderData, selectedCodes: [] }}
+      isBulkRemind
+    />);
+
+    expect(wrapper.find('.bulk-selected-codes').exists()).toBeFalsy();
+    wrapper.find('.modal-footer .btn-primary').simulate('click');
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -77,6 +77,15 @@ const sampleTableData = {
 };
 
 describe('CouponDetailsWrapper', () => {
+  let wrapper;
+  let store;
+
+  const selectAllCodesOnPage = ({ isSelected, expectedSelectionLength }) => {
+    const selectAllCheckbox = wrapper.find('table th').find('input[type=\'checkbox\']');
+    selectAllCheckbox.simulate('change', { target: { value: isSelected } });
+    expect(wrapper.find('CouponDetails').instance().state.selectedCodes).toHaveLength(expectedSelectionLength);
+  };
+
   describe('renders', () => {
     it('with collapsed coupon details', () => {
       const tree = renderer
@@ -106,7 +115,7 @@ describe('CouponDetailsWrapper', () => {
     });
 
     it('with table data', () => {
-      const store = mockStore({
+      store = mockStore({
         ...initialState,
         table: {
           'coupon-details': sampleTableData,
@@ -125,7 +134,7 @@ describe('CouponDetailsWrapper', () => {
   });
 
   it('handles isExpanded prop change', () => {
-    const wrapper = mount(<CouponDetailsWrapper isExpanded />);
+    wrapper = mount(<CouponDetailsWrapper isExpanded />);
     expect(wrapper.find(CouponDetails).prop('isExpanded')).toBeTruthy();
 
     wrapper.setProps({
@@ -140,7 +149,7 @@ describe('CouponDetailsWrapper', () => {
   });
 
   it('properly handles changes to selected toggle input', () => {
-    const wrapper = mount(<CouponDetailsWrapper isExpanded />);
+    wrapper = mount(<CouponDetailsWrapper isExpanded />);
     expect(wrapper.find('select').first().prop('value')).toEqual('unassigned');
 
     wrapper.find('select').first().simulate('change', { target: { value: 'redeemed' } });
@@ -151,21 +160,18 @@ describe('CouponDetailsWrapper', () => {
   });
 
   it('sets disabled to true when unassignedCodes === 0', () => {
-    const wrapper = mount(<CouponDetailsWrapper isExpanded unassignedCodes={0} />);
+    wrapper = mount(<CouponDetailsWrapper isExpanded unassignedCodes={0} />);
     expect(wrapper.find('select').last().prop('name')).toEqual('bulk-action');
     expect(wrapper.find('select').last().prop('disabled')).toEqual(true);
   });
 
   it('sets disabled to false when unassignedCodes !== 0', () => {
-    const wrapper = mount(<CouponDetailsWrapper isExpanded />);
+    wrapper = mount(<CouponDetailsWrapper isExpanded />);
     expect(wrapper.find('select').last().prop('name')).toEqual('bulk-action');
     expect(wrapper.find('select').last().prop('disabled')).toEqual(false);
   });
 
   describe('modals', () => {
-    let store;
-    let wrapper;
-
     const openModalByActionButton = ({ key, label }) => {
       const actionButton = wrapper.find('table').find('button').find(`.${key}-btn`);
       expect(actionButton.prop('children')).toEqual(label);
@@ -214,6 +220,11 @@ describe('CouponDetailsWrapper', () => {
       wrapper.find('.toggles select').simulate('change', { target: { value: 'unredeemed' } });
       expect(wrapper.find('.toggles select').prop('value')).toEqual('unredeemed');
 
+      selectAllCodesOnPage({
+        isSelected: true,
+        expectedSelectionLength: 3,
+      });
+
       wrapper.find('.bulk-actions select').simulate('change', { target: { value: 'remind' } });
       expect(wrapper.find('.bulk-actions select').prop('value')).toEqual('remind');
 
@@ -224,6 +235,11 @@ describe('CouponDetailsWrapper', () => {
     it('sets revoke modal state on bulk revoke click', () => {
       wrapper.find('.toggles select').simulate('change', { target: { value: 'unredeemed' } });
       expect(wrapper.find('.toggles select').prop('value')).toEqual('unredeemed');
+
+      selectAllCodesOnPage({
+        isSelected: true,
+        expectedSelectionLength: 3,
+      });
 
       wrapper.find('.bulk-actions select').simulate('change', { target: { value: 'revoke' } });
       expect(wrapper.find('.bulk-actions select').prop('value')).toEqual('revoke');
@@ -267,9 +283,6 @@ describe('CouponDetailsWrapper', () => {
   });
 
   describe('code selection', () => {
-    let store;
-    let wrapper;
-
     beforeEach(() => {
       store = mockStore({
         ...initialState,
@@ -284,12 +297,6 @@ describe('CouponDetailsWrapper', () => {
         />
       ));
     });
-
-    const selectAllCodesOnPage = ({ isSelected, expectedSelectionLength }) => {
-      const selectAllCheckbox = wrapper.find('table th').find('input[type=\'checkbox\']');
-      selectAllCheckbox.simulate('change', { target: { value: isSelected } });
-      expect(wrapper.find('CouponDetails').instance().state.selectedCodes).toHaveLength(expectedSelectionLength);
-    };
 
     it('handles individual code selection within table', () => {
       const checkboxes = wrapper.find('table').find('input[type=\'checkbox\']').slice(1);


### PR DESCRIPTION
1. Prevents submission of bulk remind form if no codes are selected (throws an error) as the remind endpoint requires specific codes to be specified.
2. Disables the "Remind"/"Revoke" options in the bulk action input select if no codes are currently selected as this wouldn't be a valid action anyways.
3. Updates the messaging in the error message of the bulk remind/revoke modals when no codes are selected.
4. Adds line break in the reminder email template.