### PR TITLE
Adding utf-8 charset and viewport meta to index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,8 @@
 <html>
   <head>
     <base href="/" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
These two meta tags are in the cookie cutter but we didn't bring them into the edx-portal yet. This will fix `edx-portal` for mobile (so it doesn't load desktop view), and should resolve the issue outlined in [ENT-1577](https://openedx.atlassian.net/browse/ENT-1577).