### PR TITLE
 Hide partial redeem toggle for single use and once per customer coupons

### DIFF
--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -31,6 +31,7 @@ const initialCouponData = {
   num_unassigned: 0,
   num_uses: 0,
   max_uses: 1,
+  usage_limitation: 'Multi-use',
 };
 
 const CouponWrapper = props => (

--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -6,6 +6,8 @@ import thunk from 'redux-thunk';
 import { shallow, mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 
+import { MULTI_USE } from '../../data/constants/coupons';
+
 import Coupon from './index';
 import CouponDetails from '../CouponDetails';
 
@@ -31,7 +33,7 @@ const initialCouponData = {
   num_unassigned: 0,
   num_uses: 0,
   max_uses: 1,
-  usage_limitation: 'Multi-use',
+  usage_limitation: MULTI_USE,
 };
 
 const CouponWrapper = props => (

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -182,11 +182,8 @@ class Coupon extends React.Component {
           </div>
         </div>
         {<CouponDetails
-          id={data.id}
           isExpanded={isExpanded}
-          hasError={data.has_error}
-          couponTitle={data.title}
-          unassignedCodes={data.num_unassigned}
+          couponData={data}
         />}
       </div>
     );

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -11,6 +11,7 @@ import CodeRevokeModal from '../../containers/CodeRevokeModal';
 import H3 from '../H3';
 import StatusAlert from '../StatusAlert';
 
+import { SINGLE_USE, ONCE_PER_CUSTOMER } from '../../data/constants/coupons';
 import EcommerceApiService from '../../data/services/EcommerceApiService';
 
 import './CouponDetails.scss';
@@ -92,7 +93,7 @@ class CouponDetails extends React.Component {
 
   getTableFilterSelectOptions() {
     const { couponData: { usage_limitation: usageLimitation } } = this.props;
-    const shouldHidePartialRedeem = ['Single use', 'Once per customer'].includes(usageLimitation);
+    const shouldHidePartialRedeem = [SINGLE_USE, ONCE_PER_CUSTOMER].includes(usageLimitation);
 
     let options = [{
       label: 'Unassigned',

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -90,9 +90,34 @@ class CouponDetails extends React.Component {
     }
   }
 
+  getTableFilterSelectOptions() {
+    const { couponData: { usage_limitation: usageLimitation } } = this.props;
+    const shouldHidePartialRedeem = ['Single use', 'Once per customer'].includes(usageLimitation);
+
+    let options = [{
+      label: 'Unassigned',
+      value: 'unassigned',
+    }, {
+      label: 'Unredeemed',
+      value: 'unredeemed',
+    }, {
+      label: 'Partially Redeemed',
+      value: 'partially-redeemed',
+    }, {
+      label: 'Redeemed',
+      value: 'redeemed',
+    }];
+
+    if (shouldHidePartialRedeem) {
+      options = options.filter(option => option.value !== 'partially-redeemed');
+    }
+
+    return options;
+  }
+
   getBulkActionSelectOptions() {
     const { selectedToggle, selectedCodes } = this.state;
-    const { unassignedCodes } = this.props;
+    const { couponData: { num_unassigned: unassignedCodes } } = this.props;
 
     const isAssignView = selectedToggle === 'unassigned';
     const isRedeemedView = selectedToggle === 'redeemed';
@@ -124,7 +149,7 @@ class CouponDetails extends React.Component {
   }
 
   getActionButton(code) {
-    const { couponTitle, id } = this.props;
+    const { couponData: { id, title: couponTitle } } = this.props;
     const {
       assigned_to: assignedTo,
       redemptions,
@@ -226,7 +251,13 @@ class CouponDetails extends React.Component {
   }
 
   handleBulkActionSelect() {
-    const { couponTitle, id, unassignedCodes } = this.props;
+    const {
+      couponData: {
+        id,
+        title: couponTitle,
+        num_unassigned: unassignedCodes,
+      },
+    } = this.props;
     const { hasAllCodesSelected, selectedCodes } = this.state;
 
     const ref = this.bulkActionSelectRef && this.bulkActionSelectRef.current;
@@ -306,7 +337,7 @@ class CouponDetails extends React.Component {
     //  - Code assignment/remind/revoke status (error or success)
     //  - Code selection status (e.g., "50 codes selected. Select all 65 codes?")
 
-    const { hasError } = this.props;
+    const { couponData: { has_error: hasError } } = this.props;
     const {
       isCodeAssignmentSuccessful,
       isCodeReminderSuccessful,
@@ -410,7 +441,7 @@ class CouponDetails extends React.Component {
   }
 
   updateCouponOverviewData() {
-    const { id } = this.props;
+    const { couponData: { id } } = this.props;
     this.props.fetchCouponOrder(id);
   }
 
@@ -574,10 +605,9 @@ class CouponDetails extends React.Component {
     } = this.state;
 
     const {
-      id,
-      hasError,
-      isExpanded,
+      couponData: { id, has_error: hasError },
       couponDetailsTable: { data: tableData },
+      isExpanded,
     } = this.props;
 
     return (
@@ -616,12 +646,7 @@ class CouponDetails extends React.Component {
                     name="table-view"
                     label="Filter by Code Status:"
                     value={selectedToggle}
-                    options={[
-                      { label: 'Unassigned', value: 'unassigned' },
-                      { label: 'Unredeemed', value: 'unredeemed' },
-                      { label: 'Partially Redeemed', value: 'partially-redeemed' },
-                      { label: 'Redeemed', value: 'redeemed' },
-                    ]}
+                    options={this.getTableFilterSelectOptions()}
                     disabled={this.isTableLoading()}
                     onChange={this.handleToggleSelect}
                   />
@@ -743,16 +768,20 @@ class CouponDetails extends React.Component {
 
 CouponDetails.defaultProps = {
   isExpanded: false,
-  hasError: false,
   couponDetailsTable: {},
 };
 
 CouponDetails.propTypes = {
-  id: PropTypes.number.isRequired,
-  unassignedCodes: PropTypes.number.isRequired,
-  isExpanded: PropTypes.bool,
-  hasError: PropTypes.bool,
+  // props from container
   couponDetailsTable: PropTypes.shape({}),
+
+  // custom props
+  couponData: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    has_error: PropTypes.bool.isRequired,
+    num_unassigned: PropTypes.number.isRequired,
+  }).isRequired,
+  isExpanded: PropTypes.bool,
 };
 
 export default CouponDetails;

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -780,6 +780,7 @@ CouponDetails.propTypes = {
     id: PropTypes.number.isRequired,
     has_error: PropTypes.bool.isRequired,
     num_unassigned: PropTypes.number.isRequired,
+    usage_limitation: PropTypes.string.isRequired,
   }).isRequired,
   isExpanded: PropTypes.bool,
 };

--- a/src/containers/CodeManagementPage/CodeManagementPage.test.jsx
+++ b/src/containers/CodeManagementPage/CodeManagementPage.test.jsx
@@ -63,6 +63,7 @@ const sampleCouponData = {
   max_uses: 10,
   num_unassigned: 2,
   num_uses: 2,
+  usage_limitation: 'Multi-use',
 };
 
 describe('CodeManagementPageWrapper', () => {

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -7,6 +7,7 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { mount } from 'enzyme';
 
+import { SINGLE_USE, MULTI_USE, ONCE_PER_CUSTOMER } from '../../data/constants/coupons';
 import EcommerceaApiService from '../../data/services/EcommerceApiService';
 
 import CouponDetails from './index';
@@ -26,7 +27,7 @@ const initialCouponData = {
   title: 'test-title',
   num_unassigned: 10,
   has_error: false,
-  usage_limitation: 'Multi-use',
+  usage_limitation: MULTI_USE,
 };
 
 const CouponDetailsWrapper = props => (
@@ -174,20 +175,7 @@ describe('CouponDetailsWrapper', () => {
       <CouponDetailsWrapper
         couponData={{
           ...initialCouponData,
-          usage_limitation: 'Single use',
-        }}
-        isExpanded
-      />
-    ));
-    options = wrapper.find('select').first().prop('children').map(option => option.props.value);
-    expect(options).toHaveLength(3);
-    expect(options.includes('partially-redeemed')).toBeFalsy();
-
-    wrapper = mount((
-      <CouponDetailsWrapper
-        couponData={{
-          ...initialCouponData,
-          usage_limitation: 'Once per customer',
+          usage_limitation: SINGLE_USE,
         }}
         isExpanded
       />
@@ -209,7 +197,7 @@ describe('CouponDetailsWrapper', () => {
       <CouponDetailsWrapper
         couponData={{
           ...initialCouponData,
-          usage_limitation: 'Once per customer',
+          usage_limitation: ONCE_PER_CUSTOMER,
         }}
         isExpanded
       />

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -26,6 +26,7 @@ const initialCouponData = {
   title: 'test-title',
   num_unassigned: 10,
   has_error: false,
+  usage_limitation: 'Multi-use',
 };
 
 const CouponDetailsWrapper = props => (

--- a/src/data/constants/coupons.js
+++ b/src/data/constants/coupons.js
@@ -4,10 +4,22 @@ const COUPONS_FAILURE = 'COUPONS_FAILURE';
 const CLEAR_COUPONS = 'CLEAR_COUPONS';
 const COUPON_SUCCESS = 'COUPON_SUCCESS';
 
+// Coupon types
+const SINGLE_USE = 'Single use';
+const MULTI_USE = 'Multi-use';
+const ONCE_PER_CUSTOMER = 'Once per customer';
+const MULTI_USE_PER_CUSTOMER = 'Multi-use-per-Customer';
+
 export {
+  // Redux action names
   COUPONS_REQUEST,
   COUPONS_SUCCESS,
   COUPONS_FAILURE,
   CLEAR_COUPONS,
   COUPON_SUCCESS,
+  // Coupon types
+  SINGLE_USE,
+  ONCE_PER_CUSTOMER,
+  MULTI_USE,
+  MULTI_USE_PER_CUSTOMER,
 };


### PR DESCRIPTION
[ENT-1580](https://openedx.atlassian.net/browse/ENT-1580)

This PR removes the "Partially Redeemed" toggle option for "Single use" and "Once per customer" coupons.

I also did some refactoring to pass through all the data associated with a coupon to the `CouponDetails` component instead of as individual props, e.g.:

```jsx
<CouponDetails
  isExpanded={isExpanded}
  couponData={data}
/>
```

instead of:

```jsx
<CouponDetails
  isExpanded={isExpanded}
  id={data.id}
  hasError={data.has_error}
  unassignedCodes={data.num_unassigned}
  couponTitle={data.title}
  // etc...
/>
```
