### PR TITLE
ENT-1522: Update coupon code remind/revoke backend and frontend with proper error checking

### DIFF
--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -56,6 +56,7 @@ class CouponDetails extends React.Component {
       isCodeAssignmentSuccessful: undefined,
       isCodeReminderSuccessful: undefined,
       isCodeRevokeSuccessful: undefined,
+      doesCodeActionHaveErrors: undefined,
       selectedCodes: [],
       hasAllCodesSelected: false,
       /**
@@ -351,6 +352,7 @@ class CouponDetails extends React.Component {
       isCodeAssignmentSuccessful,
       isCodeReminderSuccessful,
       isCodeRevokeSuccessful,
+      doesCodeActionHaveErrors,
     } = this.state;
 
     const hasStatusAlert = [
@@ -359,6 +361,7 @@ class CouponDetails extends React.Component {
       isCodeAssignmentSuccessful,
       isCodeReminderSuccessful,
       isCodeRevokeSuccessful,
+      doesCodeActionHaveErrors,
       this.shouldShowSelectAllStatusAlert(),
     ].some(item => item);
 
@@ -455,8 +458,9 @@ class CouponDetails extends React.Component {
     this.props.fetchCouponOrder(id);
   }
 
-  handleCodeActionSuccess(action) {
+  handleCodeActionSuccess(action, response) {
     let stateKey;
+    let doesCodeActionHaveErrors;
 
     switch (action) {
       case 'assign': {
@@ -465,14 +469,17 @@ class CouponDetails extends React.Component {
       }
       case 'revoke': {
         stateKey = 'isCodeRevokeSuccessful';
+        doesCodeActionHaveErrors = response && response.some && response.some(item => item.detail === 'failure');
         break;
       }
       case 'remind': {
         stateKey = 'isCodeReminderSuccessful';
+        doesCodeActionHaveErrors = response && response.some && response.some(item => item.detail === 'failure');
         break;
       }
       default: {
         stateKey = null;
+        doesCodeActionHaveErrors = null;
         break;
       }
     }
@@ -488,6 +495,7 @@ class CouponDetails extends React.Component {
         [stateKey]: true,
         refreshIndex: this.state.refreshIndex + 1, // force new table instance
         selectedCodes: [],
+        doesCodeActionHaveErrors,
       }, () => {
         this.updateSelectAllCheckBox();
       });
@@ -560,6 +568,7 @@ class CouponDetails extends React.Component {
       isCodeAssignmentSuccessful: undefined,
       isCodeReminderSuccessful: undefined,
       isCodeRevokeSuccessful: undefined,
+      doesCodeActionHaveErrors: undefined,
     });
   }
 
@@ -612,6 +621,7 @@ class CouponDetails extends React.Component {
       isCodeAssignmentSuccessful,
       isCodeReminderSuccessful,
       isCodeRevokeSuccessful,
+      doesCodeActionHaveErrors,
       refreshIndex,
       hasAllCodesSelected,
     } = this.state;
@@ -729,6 +739,10 @@ class CouponDetails extends React.Component {
                     {isCodeRevokeSuccessful && this.renderSuccessMessage({
                       message: 'Successfully revoked code(s)',
                     })}
+                    {doesCodeActionHaveErrors && this.renderErrorMessage({
+                      title: 'An unexpected error has occurred. Please try again or contact your Customer Success Manager.',
+                      message: '',
+                    })}
                     {this.shouldShowSelectAllStatusAlert() && this.renderInfoMessage({
                       message: (
                         <React.Fragment>
@@ -766,21 +780,21 @@ class CouponDetails extends React.Component {
                 <CodeAssignmentModal
                   {...modals.assignment}
                   onClose={this.resetModals}
-                  onSuccess={() => this.handleCodeActionSuccess('assign')}
+                  onSuccess={response => this.handleCodeActionSuccess('assign', response)}
                 />
               }
               {modals.revoke &&
                 <CodeRevokeModal
                   {...modals.revoke}
                   onClose={this.resetModals}
-                  onSuccess={() => this.handleCodeActionSuccess('revoke')}
+                  onSuccess={response => this.handleCodeActionSuccess('revoke', response)}
                 />
               }
               {modals.remind &&
                 <CodeReminderModal
                   {...modals.remind}
                   onClose={this.resetModals}
-                  onSuccess={() => this.handleCodeActionSuccess('remind')}
+                  onSuccess={response => this.handleCodeActionSuccess('remind', response)}
                 />
               }
             </React.Fragment>

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -433,6 +433,20 @@ describe('CouponDetailsWrapper', () => {
       // does not fetch overview data for coupon
       expect(spy).toBeCalledTimes(0);
     });
+
+    it('handles errors in response data for code reminder ', () => {
+      openModalByActionButton({
+        key: 'remind',
+        label: 'Remind',
+      });
+
+      // fake code assignment 200 status with error in response data.
+      wrapper.find('CodeReminderModal').prop('onSuccess')([{ detail: 'failure' }]);
+      expect(wrapper.find('CouponDetails').instance().state.doesCodeActionHaveErrors).toBeTruthy();
+
+      // does not fetch overview data for coupon
+      expect(spy).toBeCalledTimes(0);
+    });
   });
 
   describe('code selection', () => {


### PR DESCRIPTION
**JIRA TIcket:** [ENT-1522](https://openedx.atlassian.net/browse/ENT-1522)

**Description:**
Currently, remind/revoke endpoints return HTTP 200 even if there is an error. We do send the error message in the returned response but frontend ignores that and show a generic successful message which is misleading because, in reality, it happens that remind/revoke failed for every assignment and we showed the successful message on the frontend. It would be nice to consider the error messages coming from the server and either highlight the rows to show that remind/revoke failed or some better way to convey the error message.

**Acceptance Criteria:**
Correctly show the error message to the user if there is an error with remind/revoke.
