### PR TITLE
Support assigning more than num selected codes for "once per customer" coupons

### DIFF
--- a/src/components/CodeAssignmentModal/index.jsx
+++ b/src/components/CodeAssignmentModal/index.jsx
@@ -11,6 +11,7 @@ import BulkAssignFields from './BulkAssignFields';
 import IndividualAssignFields from './IndividualAssignFields';
 
 import emailTemplate from './emailTemplate';
+import { ONCE_PER_CUSTOMER } from '../../data/constants/coupons';
 
 import './CodeAssignmentModal.scss';
 
@@ -69,7 +70,7 @@ class CodeAssignmentModal extends React.Component {
   }
 
   validateBulkAssign(formData) {
-    const { data: { unassignedCodes } } = this.props;
+    const { data: { unassignedCodes, couponType } } = this.props;
 
     const textAreaKey = 'email-addresses';
     const csvFileKey = 'csv-email-addresses';
@@ -122,7 +123,7 @@ class CodeAssignmentModal extends React.Component {
       errors[textAreaKey] = message;
       errors._error.push(message);
     } else if (
-      textAreaEmails && numberOfSelectedCodes &&
+      textAreaEmails && numberOfSelectedCodes && couponType !== ONCE_PER_CUSTOMER &&
       textAreaEmails.length > numberOfSelectedCodes
     ) {
       const message = getTooManyAssignmentsMessage({
@@ -145,7 +146,10 @@ class CodeAssignmentModal extends React.Component {
 
       errors[csvFileKey] = message;
       errors._error.push(message);
-    } else if (csvEmails && numberOfSelectedCodes && csvEmails.length > numberOfSelectedCodes) {
+    } else if (
+      csvEmails && numberOfSelectedCodes && couponType !== ONCE_PER_CUSTOMER &&
+      csvEmails.length > numberOfSelectedCodes
+    ) {
       const message = getTooManyAssignmentsMessage({
         isCsv: true,
         emails: csvEmails,
@@ -257,8 +261,17 @@ class CodeAssignmentModal extends React.Component {
         this.props.onSuccess(response);
       })
       .catch((error) => {
+        const { response, message } = error;
+        const nonFieldErrors = response && response.data && response.data.non_field_errors;
+
+        let errors = [message];
+
+        if (nonFieldErrors) {
+          errors = [errors, ...nonFieldErrors];
+        }
+
         throw new SubmissionError({
-          _error: [error.message],
+          _error: errors,
         });
       });
   }

--- a/src/components/CodeAssignmentModal/index.jsx
+++ b/src/components/CodeAssignmentModal/index.jsx
@@ -11,7 +11,7 @@ import BulkAssignFields from './BulkAssignFields';
 import IndividualAssignFields from './IndividualAssignFields';
 
 import emailTemplate from './emailTemplate';
-import { ONCE_PER_CUSTOMER } from '../../data/constants/coupons';
+import { ONCE_PER_CUSTOMER, MULTI_USE } from '../../data/constants/coupons';
 
 import './CodeAssignmentModal.scss';
 
@@ -79,6 +79,7 @@ class CodeAssignmentModal extends React.Component {
     const csvEmails = formData[csvFileKey];
 
     const numberOfSelectedCodes = this.getNumberOfSelectedCodes();
+    const shouldValidateSelectedCodes = ![ONCE_PER_CUSTOMER, MULTI_USE].includes(couponType);
 
     const getTooManyAssignmentsMessage = ({
       isCsv = false,
@@ -123,7 +124,7 @@ class CodeAssignmentModal extends React.Component {
       errors[textAreaKey] = message;
       errors._error.push(message);
     } else if (
-      textAreaEmails && numberOfSelectedCodes && couponType !== ONCE_PER_CUSTOMER &&
+      textAreaEmails && numberOfSelectedCodes && shouldValidateSelectedCodes &&
       textAreaEmails.length > numberOfSelectedCodes
     ) {
       const message = getTooManyAssignmentsMessage({
@@ -147,7 +148,7 @@ class CodeAssignmentModal extends React.Component {
       errors[csvFileKey] = message;
       errors._error.push(message);
     } else if (
-      csvEmails && numberOfSelectedCodes && couponType !== ONCE_PER_CUSTOMER &&
+      csvEmails && numberOfSelectedCodes && shouldValidateSelectedCodes &&
       csvEmails.length > numberOfSelectedCodes
     ) {
       const message = getTooManyAssignmentsMessage({

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -261,6 +261,7 @@ class CouponDetails extends React.Component {
         id,
         title: couponTitle,
         num_unassigned: unassignedCodes,
+        usage_limitation: couponType,
       },
     } = this.props;
     const { hasAllCodesSelected, selectedCodes, selectedToggle } = this.state;
@@ -279,6 +280,7 @@ class CouponDetails extends React.Component {
             unassignedCodes,
             selectedCodes: hasAllCodesSelected ? [] : selectedCodes,
             hasAllCodesSelected,
+            couponType,
           },
         },
       });


### PR DESCRIPTION
[ENT-1573](https://openedx.atlassian.net/browse/ENT-1573)

For "Once per customer" coupons, we should allow the user to assign more emails than the number of selected codes since an individual code can be assigned to multiple users.

This PR removes the validation check for "Once per customer" coupons that looks to see if the number of emails provided is <= the number of selected codes. This will allow more emails to be assigned than the number of selected codes per the ticket description.

If a particular cannot be assigned, the modal will show an error and display the associated error message. In some cases, the response will contain an array of `non_field_errors` which should be included in the error status alert within the modal. If these `non_field_errors` exist in the response, we now include them in the status alert.