### PR TITLE
Fix partial select status after code action success

### DIFF
--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -484,6 +484,8 @@ class CouponDetails extends React.Component {
         [stateKey]: true,
         refreshIndex: this.state.refreshIndex + 1, // force new table instance
         selectedCodes: [],
+      }, () => {
+        this.updateSelectAllCheckBox();
       });
     }
   }


### PR DESCRIPTION
Currently, the "select all" checkbox remains in a partial state after a successful code action. To fix, we should call `this.updateSelectAllCheckBox()` after a code action success to ensure the checkbox gets updated properly.