### PR TITLE
Improved error messages display

### DIFF
--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -33,7 +33,7 @@ const initialCouponData = {
   title: 'Test Coupon',
   start_date: '2018-06-01T12:00:00Z',
   end_date: '2019-02-01T12:00:00Z',
-  has_error: false,
+  errors: [],
   num_unassigned: 0,
   num_uses: 0,
   max_uses: 1,
@@ -92,7 +92,7 @@ describe('<Coupon />', () => {
           <CouponWrapper
             data={{
               ...initialCouponData,
-              has_error: true,
+              errors: [{ code: 'test-code', user_email: 'test@example.com' }],
             }}
           />
         ))

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -121,7 +121,7 @@ class Coupon extends React.Component {
           'coupon mb-3 mb-lg-2 rounded border',
           {
             expanded: isExpanded,
-            'border-danger': data.has_error && !isExpanded,
+            'border-danger': data.errors.length > 0 && !isExpanded,
             dimmed,
           },
         )}
@@ -177,7 +177,7 @@ class Coupon extends React.Component {
             </div>
           </div>
           <div className="icons col-lg-1 order-first order-lg-last text-right pr-2 mt-1 m-lg-0">
-            {data.has_error && !isExpanded && this.renderErrorIcon()}
+            {data.errors.length > 0 && !isExpanded && this.renderErrorIcon()}
             {this.renderExpandCollapseIcon()}
           </div>
         </div>
@@ -201,7 +201,7 @@ Coupon.propTypes = {
     title: PropTypes.string.isRequired,
     start_date: PropTypes.string.isRequired,
     end_date: PropTypes.string.isRequired,
-    has_error: PropTypes.bool.isRequired,
+    errors: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     num_unassigned: PropTypes.number.isRequired,
     num_uses: PropTypes.number.isRequired,
     max_uses: PropTypes.number,

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -352,7 +352,7 @@ class CouponDetails extends React.Component {
     //  - Code selection status (e.g., "50 codes selected. Select all 65 codes?")
 
     const {
-      couponData: { has_error: hasError },
+      couponData: { errors },
       couponOverviewError,
     } = this.props;
     const {
@@ -363,7 +363,7 @@ class CouponDetails extends React.Component {
     } = this.state;
 
     const hasStatusAlert = [
-      hasError,
+      errors.length > 0,
       couponOverviewError,
       isCodeAssignmentSuccessful,
       isCodeReminderSuccessful,
@@ -591,12 +591,15 @@ class CouponDetails extends React.Component {
   }
 
   renderSuccessMessage({ title, message }) {
-    const { hasError, couponOverviewError } = this.props;
+    const {
+      couponData: { errors },
+      couponOverviewError,
+    } = this.props;
 
     return (
       <StatusAlert
         alertType="success"
-        className={[classNames({ 'mt-2': hasError || couponOverviewError })]}
+        className={[classNames({ 'mt-2': errors.length > 0 || couponOverviewError })]}
         iconClassNames={['fa', 'fa-check']}
         title={title}
         message={message}
@@ -607,12 +610,15 @@ class CouponDetails extends React.Component {
   }
 
   renderInfoMessage({ title, message }) {
-    const { hasError, couponOverviewError } = this.props;
+    const {
+      couponData: { errors },
+      couponOverviewError,
+    } = this.props;
 
     return (
       <StatusAlert
         alertType="info"
-        className={[classNames({ 'mt-2': hasError || couponOverviewError })]}
+        className={[classNames({ 'mt-2': errors.length > 0 || couponOverviewError })]}
         title={title}
         message={message}
       />
@@ -634,7 +640,7 @@ class CouponDetails extends React.Component {
     } = this.state;
 
     const {
-      couponData: { id, has_error: hasError },
+      couponData: { id, errors },
       couponDetailsTable: { data: tableData },
       couponOverviewLoading,
       couponOverviewError,
@@ -704,8 +710,21 @@ class CouponDetails extends React.Component {
               {this.hasStatusAlert() &&
                 <div className="row mb-3">
                   <div className="col">
-                    {hasError && this.renderErrorMessage({
-                      message: 'One or more codes below have an error.',
+                    {errors.length > 0 && this.renderErrorMessage({
+                      message: (
+                        <React.Fragment>
+                          {errors.length > 1 ?
+                            `${errors.length} errors have occurred: ` : 'An error has occurred: '}
+                          <ul className="m-0 pl-4">
+                            {errors.map(error => (
+                              <li key={error.code}>
+                                {`Unable to send code assignment email to
+                                 ${error.user_email} for ${error.code} code.`}
+                              </li>
+                            ))}
+                          </ul>
+                        </React.Fragment>
+                      ),
                     })}
                     {couponOverviewError && !couponOverviewLoading && this.renderErrorMessage({
                       message: (
@@ -824,7 +843,7 @@ CouponDetails.propTypes = {
   // custom props
   couponData: PropTypes.shape({
     id: PropTypes.number.isRequired,
-    has_error: PropTypes.bool.isRequired,
+    errors: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     num_unassigned: PropTypes.number.isRequired,
     usage_limitation: PropTypes.string.isRequired,
   }).isRequired,

--- a/src/containers/CodeManagementPage/CodeManagementPage.test.jsx
+++ b/src/containers/CodeManagementPage/CodeManagementPage.test.jsx
@@ -59,7 +59,7 @@ const sampleCouponData = {
   title: 'test-title-1',
   start_date: '2019-01-03T23:23:51.581Z',
   end_date: '2019-09-18T14:46:36.716Z',
-  has_error: false,
+  errors: [],
   max_uses: 10,
   num_unassigned: 2,
   num_uses: 2,

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -30,7 +30,7 @@ const initialCouponData = {
   id: 1,
   title: 'test-title',
   num_unassigned: 10,
-  has_error: false,
+  errors: [],
   usage_limitation: MULTI_USE,
 };
 
@@ -125,7 +125,7 @@ describe('CouponDetailsWrapper', () => {
           <CouponDetailsWrapper
             couponData={{
               ...initialCouponData,
-              has_error: true,
+              errors: [{ code: 'test-code', user_email: 'test@example.com' }],
             }}
             isExpanded
           />

--- a/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
+++ b/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
@@ -200,7 +200,15 @@ exports[`CouponDetailsWrapper renders with error 1`] = `
               <div
                 className="message"
               >
-                One or more codes below have an error.
+                An error has occurred: 
+                <ul
+                  className="m-0 pl-4"
+                >
+                  <li>
+                    Unable to send code assignment email to
+                                 test@example.com for test-code code.
+                  </li>
+                </ul>
               </div>
             </div>
           </div>

--- a/src/demo/coupons.js
+++ b/src/demo/coupons.js
@@ -67,7 +67,7 @@ const coupons = [...Array(couponsCount)].map((_, index) => {
     num_unassigned: faker.random.number({ min: 1, max: 20 }),
     num_uses: faker.random.number({ min: 1, max: totalEnrollments }),
     max_uses: faker.random.boolean() ? totalEnrollments : null,
-    has_error: false,
+    errors: [],
   };
 });
 
@@ -186,7 +186,13 @@ const getCodesCsv = () => allCodes.reduce((csvData, code) => (
   `${csvData}${getCsvRow(code)}\n`
 ), `${getCsvHeaders()}\n`);
 
-coupons[0].has_error = firstCouponHasError;
+// Attach errors
+coupons[0].errors = getAllCodes(firstCouponHasError)
+  .filter(codeItem => codeItem.error)
+  .map(codeItem => ({
+    code: codeItem.code,
+    user_email: codeItem.assigned_to,
+  }));
 
 export {
   coupons,

--- a/src/demo/rewireEcommerceApiService.js
+++ b/src/demo/rewireEcommerceApiService.js
@@ -2,7 +2,7 @@ import EcommerceApiService from '../../src/data/services/EcommerceApiService';
 
 import { codes, codesCsv, coupons } from './data';
 
-const firstCouponHasError = coupons[0].has_error;
+const firstCouponHasError = coupons[0].errors.length > 0;
 
 const findCouponIndexById = couponId =>
   coupons.findIndex(coupon => coupon.id === couponId);
@@ -31,7 +31,7 @@ const rewire = () => {
         data: codesCsv(),
       });
     }
-    const couponData = coupons[findCouponIndexById(couponId)].has_error ?
+    const couponData = coupons[findCouponIndexById(couponId)].errors.length > 0 ?
       codes({
         codeFilter: options.code_filter,
         couponHasError: firstCouponHasError,


### PR DESCRIPTION
This PR improves error message display for a coupon.

Previously, a coupon used to get `has_error` key which is now changed to give us a complete list of errors if any.

```javascript
errors: [{'code': 'JKAPSIJ', 'user_email': 'test@example.com'}, {'code': 'CHJKNEM': 'user_email': 'test2@example.com'}]
```

This is how errors would be now show:

**1) In case of a single error**

<img width="1208" alt="error message with 1 error" src="https://user-images.githubusercontent.com/6991154/53567092-2a8d1680-3b2c-11e9-9685-3b6af3ecb7dd.png">

**2) In case of multiple errors**

<img width="1199" alt="error message with more tha 1 error" src="https://user-images.githubusercontent.com/6991154/53567099-2fea6100-3b2c-11e9-99e7-c35e1729da88.png">

[ENT-1531](https://openedx.atlassian.net/browse/ENT-1531)