### PR TITLE
Fixed request codes success banner not properly showing bug.

### DIFF
--- a/src/components/CodeManagement/index.jsx
+++ b/src/components/CodeManagement/index.jsx
@@ -25,32 +25,24 @@ class CodeManagement extends React.Component {
   }
 
   componentDidMount() {
-    const { enterpriseId } = this.props;
-
+    const { enterpriseId, location } = this.props;
     if (enterpriseId) {
       this.props.fetchCouponOrders();
+    }
+    if (location.state && location.state.hasRequestedCodes) {
+      this.setState({ // eslint-disable-line react/no-did-mount-set-state
+        hasRequestedCodes: location.state.hasRequestedCodes,
+      });
     }
   }
 
   componentDidUpdate(prevProps) {
-    const { enterpriseId, location, history } = this.props;
-
+    const { enterpriseId } = this.props;
     if (enterpriseId && enterpriseId !== prevProps.enterpriseId) {
       this.props.fetchCouponOrders();
     }
-
-    if (location.state && location.state.hasRequestedCodes && location !== prevProps.location) {
-      this.setState({ // eslint-disable-line react/no-did-update-set-state
-        hasRequestedCodes: location.state.hasRequestedCodes,
-      });
-
-      // reset location state so the "requested more codes" status alert disappears
-      history.replace({
-        ...location.pathname,
-        state: {},
-      });
-    }
   }
+
 
   componentWillUnmount() {
     this.props.clearCouponOrders();

--- a/src/components/CodeManagement/index.jsx
+++ b/src/components/CodeManagement/index.jsx
@@ -25,7 +25,7 @@ class CodeManagement extends React.Component {
   }
 
   componentDidMount() {
-    const { enterpriseId, location } = this.props;
+    const { enterpriseId, location, history } = this.props;
     if (enterpriseId) {
       this.props.fetchCouponOrders();
     }
@@ -34,6 +34,10 @@ class CodeManagement extends React.Component {
         hasRequestedCodes: location.state.hasRequestedCodes,
       });
     }
+    history.replace({
+      ...location.pathname,
+      state: {},
+    });
   }
 
   componentDidUpdate(prevProps) {
@@ -42,7 +46,6 @@ class CodeManagement extends React.Component {
       this.props.fetchCouponOrders();
     }
   }
-
 
   componentWillUnmount() {
     this.props.clearCouponOrders();

--- a/src/containers/CodeManagementPage/CodeManagementPage.test.jsx
+++ b/src/containers/CodeManagementPage/CodeManagementPage.test.jsx
@@ -142,15 +142,14 @@ describe('CodeManagementPageWrapper', () => {
 
   describe('correctly handles prop changes', () => {
     it('handles location.state change', () => {
-      const wrapper = mount(<CodeManagementPageWrapper />);
-
-      wrapper.setProps({
-        location: {
+      const wrapper = mount((
+        <CodeManagementPageWrapper location={{
           state: {
             hasRequestedCodes: true,
           },
-        },
-      });
+        }}
+        />
+      ));
 
       expect(wrapper.find('CodeManagement').instance().state.hasRequestedCodes).toBeTruthy();
     });


### PR DESCRIPTION
It was an issue with remounting the code management page after redirecting back from the request form. It was solved by checking props on mount instead of on receiving now props. Also changed a test to reflect the new structure.