### PR TITLE
Fixes pagination / history for Code Management

### DIFF
--- a/src/components/CodeManagement/index.jsx
+++ b/src/components/CodeManagement/index.jsx
@@ -72,7 +72,7 @@ class CodeManagement extends React.Component {
       ));
 
       if (!couponWithIdExists) {
-        this.removeCouponIdQueryParam();
+        this.removeQueryParams(['coupon_id', 'page']);
       }
     }
 
@@ -107,11 +107,13 @@ class CodeManagement extends React.Component {
     }
   }
 
-  removeCouponIdQueryParam() {
+  removeQueryParams(keys) {
     const { location } = this.props;
     const queryParams = qs.parse(location.search);
 
-    queryParams.coupon_id = undefined;
+    keys.forEach((key) => {
+      queryParams[key] = undefined;
+    });
 
     updateUrl(queryParams);
   }
@@ -123,7 +125,7 @@ class CodeManagement extends React.Component {
 
   handleRefreshData() {
     this.paginateCouponOrders(1);
-    this.removeCouponIdQueryParam();
+    this.removeQueryParams(['coupon_id', 'page', 'overview_page']);
   }
 
   handleCouponExpand(selectedIndex) {
@@ -142,7 +144,7 @@ class CodeManagement extends React.Component {
 
   handleCouponCollapse() {
     this.setCouponOpacity();
-    this.removeCouponIdQueryParam();
+    this.removeQueryParams(['coupon_id', 'page']);
   }
 
   hasCouponData(coupons) {

--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -197,4 +197,20 @@ describe('<Coupon />', () => {
     instance.closeCouponDetails(true);
     expect(instance.state.isExpanded).toBeFalsy();
   });
+
+  it('sets state correctly for isExpanded prop on componentDidMount', () => {
+    wrapper = mount(<CouponWrapper isExpanded />);
+    expect(wrapper.find(Coupon).instance().state.isExpanded).toBeTruthy();
+  });
+
+  it('correctly handles isExpanded prop change', () => {
+    wrapper = mount(<CouponWrapper />);
+    expect(wrapper.find(Coupon).instance().state.isExpanded).toBeFalsy();
+
+    wrapper.setProps({
+      isExpanded: true,
+    });
+
+    expect(wrapper.find(Coupon).instance().state.isExpanded).toBeTruthy();
+  });
 });

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -27,6 +27,26 @@ class Coupon extends React.Component {
     this.handleCouponKeyDown = this.handleCouponKeyDown.bind(this);
   }
 
+  componentDidMount() {
+    const { isExpanded } = this.props;
+
+    if (isExpanded) {
+      this.setState({ // eslint-disable-line react/no-did-mount-set-state
+        isExpanded,
+      });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isExpanded } = this.props;
+
+    if (isExpanded !== prevProps.isExpanded) {
+      this.setState({ // eslint-disable-line react/no-did-update-set-state
+        isExpanded,
+      });
+    }
+  }
+
   setCouponOpacity(dimmedStatus) {
     this.setState({
       dimmed: dimmedStatus,
@@ -191,6 +211,7 @@ class Coupon extends React.Component {
 }
 
 Coupon.defaultProps = {
+  isExpanded: false,
   onExpand: () => {},
   onCollapse: () => {},
 };
@@ -206,6 +227,7 @@ Coupon.propTypes = {
     num_uses: PropTypes.number.isRequired,
     max_uses: PropTypes.number,
   }).isRequired,
+  isExpanded: PropTypes.bool,
   onExpand: PropTypes.func,
   onCollapse: PropTypes.func,
 };

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -836,11 +836,16 @@ class CouponDetails extends React.Component {
 CouponDetails.defaultProps = {
   isExpanded: false,
   couponDetailsTable: {},
+  couponOverviewError: null,
+  couponOverviewLoading: false,
 };
 
 CouponDetails.propTypes = {
   // props from container
+  fetchCouponOrder: PropTypes.func.isRequired,
   couponDetailsTable: PropTypes.shape({}),
+  couponOverviewError: PropTypes.instanceOf(Error),
+  couponOverviewLoading: PropTypes.bool,
 
   // custom props
   couponData: PropTypes.shape({

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -125,7 +125,7 @@ class EnterpriseApp extends React.Component {
                     <Route
                       key="code-management"
                       exact
-                      path={`${baseUrl}/admin/codes`}
+                      path={`${baseUrl}/admin/coupons`}
                       render={routeProps =>
                         <CodeManagementPage {...routeProps} />
                       }
@@ -133,7 +133,7 @@ class EnterpriseApp extends React.Component {
                     <Route
                       key="request-codes"
                       exact
-                      path={`${baseUrl}/admin/codes/request`}
+                      path={`${baseUrl}/admin/coupons/request`}
                       render={routeProps =>
                         <RequestCodesPage {...routeProps} />
                       }

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -50,7 +50,7 @@ class Sidebar extends React.Component {
       },
       {
         title: 'Code Management',
-        to: `${baseUrl}/admin/codes`,
+        to: `${baseUrl}/admin/coupons`,
         iconClassName: 'fa-tags',
         hidden: !features.CODE_MANAGEMENT || !enableCodeManagementScreen,
       },

--- a/src/containers/CodeManagementPage/CodeManagementPage.test.jsx
+++ b/src/containers/CodeManagementPage/CodeManagementPage.test.jsx
@@ -140,25 +140,49 @@ describe('CodeManagementPageWrapper', () => {
     });
   });
 
-  describe('correctly handles prop changes', () => {
-    it('handles location.state change', () => {
-      const wrapper = mount((
-        <CodeManagementPageWrapper location={{
+  it('handles location.state on componentDidMount', () => {
+    const wrapper = mount((
+      <CodeManagementPageWrapper
+        location={{
           state: {
             hasRequestedCodes: true,
           },
         }}
-        />
-      ));
+      />
+    ));
 
-      expect(wrapper.find('CodeManagement').instance().state.hasRequestedCodes).toBeTruthy();
+    expect(wrapper.find('CodeManagement').instance().state.hasRequestedCodes).toBeTruthy();
+  });
+
+  it('handles overview_page query parameter change', () => {
+    const store = mockStore({
+      ...initialState,
+      coupons: {
+        ...initialState.coupons,
+        data: {
+          count: 100,
+          num_pages: 2,
+          results: [...Array(50)].map((_, index) => ({ ...sampleCouponData, id: index })),
+        },
+      },
     });
+    const spy = jest.spyOn(store, 'dispatch');
+
+    const wrapper = mount(<CodeManagementPageWrapper store={store} />);
+
+    spy.mockRestore();
+
+    wrapper.setProps({
+      location: {
+        search: '?overview_page=2',
+      },
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('calls clearCouponOrders() on componentWillUnmount', () => {
-    const store = mockStore({
-      ...initialState,
-    });
+    const store = mockStore({ ...initialState });
 
     const wrapper = mount(<CodeManagementPageWrapper store={store} />);
     wrapper.unmount();

--- a/src/containers/CouponDetails/index.jsx
+++ b/src/containers/CouponDetails/index.jsx
@@ -1,10 +1,14 @@
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
 import CouponDetails from '../../components/CouponDetails';
+
 import { fetchCouponOrder } from '../../data/actions/coupons';
 
+const couponDetailsTableId = 'coupon-details';
+
 const mapStateToProps = state => ({
-  couponDetailsTable: state.table['coupon-details'],
+  couponDetailsTable: state.table[couponDetailsTableId],
   couponOverviewError: state.coupons.couponOverviewError,
   couponOverviewLoading: state.coupons.couponOverviewLoading,
 });
@@ -15,4 +19,7 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(CouponDetails);
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CouponDetails));

--- a/src/containers/EnterpriseApp/__snapshots__/EnterpriseApp.test.jsx.snap
+++ b/src/containers/EnterpriseApp/__snapshots__/EnterpriseApp.test.jsx.snap
@@ -85,7 +85,7 @@ exports[`EnterpriseApp renders not found page correctly 1`] = `
           <a
             aria-current={null}
             className="btn btn-link btn-block text-left text-secondary rounded-0"
-            href="//admin/codes"
+            href="//admin/coupons"
             onClick={[Function]}
           >
             <span

--- a/src/containers/Sidebar/__snapshots__/Sidebar.test.jsx.snap
+++ b/src/containers/Sidebar/__snapshots__/Sidebar.test.jsx.snap
@@ -43,7 +43,7 @@ exports[`<Sidebar /> renders correctly 1`] = `
         <a
           aria-current={null}
           className="btn btn-link btn-block text-left text-secondary rounded-0"
-          href="/test-enterprise-slug/admin/codes"
+          href="/test-enterprise-slug/admin/coupons"
           onClick={[Function]}
         >
           <span
@@ -144,7 +144,7 @@ exports[`<Sidebar /> renders correctly when expanded 1`] = `
         <a
           aria-current={null}
           className="btn btn-link btn-block text-left text-secondary rounded-0"
-          href="/test-enterprise-slug/admin/codes"
+          href="/test-enterprise-slug/admin/coupons"
           onClick={[Function]}
         >
           <span
@@ -199,7 +199,7 @@ exports[`<Sidebar /> renders correctly when expanded by toggle 1`] = `
         <a
           aria-current={null}
           className="btn btn-link btn-block text-left text-secondary rounded-0"
-          href="/test-enterprise-slug/admin/codes"
+          href="/test-enterprise-slug/admin/coupons"
           onClick={[Function]}
         >
           <span

--- a/src/data/reducers/table.js
+++ b/src/data/reducers/table.js
@@ -55,7 +55,6 @@ const tableReducer = (state = {}, action) => {
       });
     case CLEAR_TABLE:
       return updateTable(state, action.payload.tableId, {
-        loading: false,
         error: null,
         ordering: null,
         data: null,

--- a/src/data/reducers/table.test.js
+++ b/src/data/reducers/table.test.js
@@ -74,7 +74,6 @@ describe('table reducer', () => {
     };
     const expected = {
       'table-1': {
-        loading: false,
         error: null,
         ordering: null,
         data: null,

--- a/src/data/services/EcommerceApiService.js
+++ b/src/data/services/EcommerceApiService.js
@@ -11,7 +11,7 @@ class EcommerceApiService {
     const { enterpriseId } = store.getState().portalConfiguration;
     const queryParams = {
       page: 1,
-      page_size: 50,
+      page_size: 2,
       ...options,
     };
 

--- a/src/data/services/EcommerceApiService.js
+++ b/src/data/services/EcommerceApiService.js
@@ -11,7 +11,7 @@ class EcommerceApiService {
     const { enterpriseId } = store.getState().portalConfiguration;
     const queryParams = {
       page: 1,
-      page_size: 2,
+      page_size: 50,
       ...options,
     };
 


### PR DESCRIPTION
[ENT-1491](https://openedx.atlassian.net/browse/ENT-1491)

For coupon pagination, we modify the `overview_page` query parameter. For code pagination (coupon details), we modify the `page` query parameter.

When a coupon is expanded, a `coupon_id` query parameter is added. This gets removed when the coupon is collapsed. On initial page load, if the `coupon_id` query parameter is set, the component will try to expand the coupon with that id. If the id is not in the results from the API, the `coupon_id` query parameter is removed.

For example, if you expand a coupon on page 2 of the overview page, and are on page 3 of the coupon details, the URL would look something like: `/coupons?coupon_id=1&overview_page=2&page=3`.

This now supports pagination for both coupons and codes, as well as deep linking to specific coupons.

I've also tested how the component handles history (i.e., browser back/forward buttons).