### PR TITLE
Minor fix for ensuring the coupon opacities are correct

### DIFF
--- a/src/components/CodeManagement/index.jsx
+++ b/src/components/CodeManagement/index.jsx
@@ -91,16 +91,15 @@ class CodeManagement extends React.Component {
 
   setCouponOpacity(couponId) {
     const couponRefs = this.getCouponRefs();
-    const hasDimmedCoupons = couponRefs.some(coupon => coupon.state.dimmed);
 
-    if (couponId && !hasDimmedCoupons) {
+    if (couponId) {
       couponRefs.forEach((coupon) => {
         const { data: { id } } = coupon.props;
         if (id !== parseInt(couponId, 10)) {
           coupon.setCouponOpacity(true);
         }
       });
-    } else if (!couponId && hasDimmedCoupons) {
+    } else {
       couponRefs.forEach((coupon) => {
         coupon.setCouponOpacity(false);
       });


### PR DESCRIPTION
When testing the recent pagination changes on stage, I noticed the opacity of the coupons were not always correct. I did some more testing locally and did a minor refactor the logic in `setCouponOpacity` function to fix the issue.