### PR TITLE
Restrict bounced codes on redeemed toggle

### DIFF
--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -649,6 +649,8 @@ class CouponDetails extends React.Component {
       isExpanded,
     } = this.props;
 
+    const shouldDisplayErrors = selectedToggle === 'unredeemed' && errors.length > 0;
+
     return (
       <div
         id={`coupon-details-${id}`}
@@ -712,7 +714,7 @@ class CouponDetails extends React.Component {
               {this.hasStatusAlert() &&
                 <div className="row mb-3">
                   <div className="col">
-                    {errors.length > 0 && this.renderErrorMessage({
+                    {shouldDisplayErrors && this.renderErrorMessage({
                       message: (
                         <React.Fragment>
                           {errors.length > 1 ?

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -10,6 +10,7 @@ import { mount } from 'enzyme';
 import { SINGLE_USE, MULTI_USE, ONCE_PER_CUSTOMER } from '../../data/constants/coupons';
 import EcommerceaApiService from '../../data/services/EcommerceApiService';
 
+import CouponDetailsComponent from '../../components/CouponDetails';
 import CouponDetails from './index';
 
 const mockStore = configureMockStore([thunk]);
@@ -120,18 +121,17 @@ describe('CouponDetailsWrapper', () => {
     });
 
     it('with error', () => {
-      const tree = renderer
-        .create((
-          <CouponDetailsWrapper
-            couponData={{
-              ...initialCouponData,
-              errors: [{ code: 'test-code', user_email: 'test@example.com' }],
-            }}
-            isExpanded
-          />
-        ))
-        .toJSON();
-      expect(tree).toMatchSnapshot();
+      const tree = renderer.create((
+        <CouponDetailsWrapper
+          couponData={{
+            ...initialCouponData,
+            errors: [{ code: 'test-code', user_email: 'test@example.com' }],
+          }}
+          isExpanded
+        />
+      ));
+      tree.root.findByType(CouponDetailsComponent).instance.setState({ selectedToggle: 'unredeemed' });
+      expect(tree.toJSON()).toMatchSnapshot();
     });
 
     it('with table data', () => {

--- a/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
+++ b/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
@@ -76,7 +76,7 @@ exports[`CouponDetailsWrapper renders with error 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             type="select"
-            value="unassigned"
+            value="unredeemed"
           >
             <option
               value="unassigned"


### PR DESCRIPTION
Restrict bounced codes on redeemed toggle because it does not make sense to show error messages for codes that do not appear on unassigned, redeeemed or partial-redeemed toggles.

[ENT-1635](https://openedx.atlassian.net/browse/ENT-1635)