### PR TITLE
ENT-1714: Update Overview to Include Assignments Remaining

### DIFF
--- a/src/components/Coupon/__snapshots__/Coupon.test.jsx.snap
+++ b/src/components/Coupon/__snapshots__/Coupon.test.jsx.snap
@@ -69,7 +69,7 @@ exports[`<Coupon /> renders correctly with error state 1`] = `
           <small
             className="text-muted"
           >
-            Unassigned Codes
+            Assignments Remaining
           </small>
           <div>
             0
@@ -199,7 +199,7 @@ exports[`<Coupon /> renders correctly with max uses 1`] = `
           <small
             className="text-muted"
           >
-            Unassigned Codes
+            Assignments Remaining
           </small>
           <div>
             0
@@ -319,7 +319,7 @@ exports[`<Coupon /> renders correctly without max uses 1`] = `
           <small
             className="text-muted"
           >
-            Unassigned Codes
+            Assignments Remaining
           </small>
           <div>
             0

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -185,7 +185,7 @@ class Coupon extends React.Component {
           <div className="col-sm-12 col-lg-4 mb-2 mb-lg-0">
             <div className="row no-gutters">
               <div className="col">
-                <small className={classNames({ 'text-muted': !isExpanded, 'text-light': isExpanded })}>Unassigned Codes</small>
+                <small className={classNames({ 'text-muted': !isExpanded, 'text-light': isExpanded })}>Assignments Remaining</small>
                 <div>{data.num_unassigned}</div>
               </div>
               <div className="col">

--- a/src/containers/CodeManagementPage/__snapshots__/CodeManagementPage.test.jsx.snap
+++ b/src/containers/CodeManagementPage/__snapshots__/CodeManagementPage.test.jsx.snap
@@ -488,7 +488,7 @@ Array [
                   <small
                     className="text-muted"
                   >
-                    Unassigned Codes
+                    Assignments Remaining
                   </small>
                   <div>
                     2
@@ -605,7 +605,7 @@ Array [
                   <small
                     className="text-muted"
                   >
-                    Unassigned Codes
+                    Assignments Remaining
                   </small>
                   <div>
                     2


### PR DESCRIPTION
**Description:**
Currently, the overview shows "unassigned codes" but this doesn't actually show the # of un-assignments remaining i.e. if 1 code has 500 potential assignments, it will always only show 1. It would be more useful to the admin to know the # of assignments there are left for them to take action on.