### PR TITLE
Replace `with_access_to` calls with `dashboard_list` calls

### DIFF
--- a/src/data/actions/enterpriseList.test.js
+++ b/src/data/actions/enterpriseList.test.js
@@ -53,13 +53,12 @@ describe('actions', () => {
       ];
       const store = mockStore();
       const defaultOptions = {
-        permissions: 'enterprise_data_api_access',
         page: 1,
         page_size: 50,
         search: 'test-search-string',
       };
 
-      axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/with_access_to/?${qs.stringify(defaultOptions)}`)
+      axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/dashboard_list/?${qs.stringify(defaultOptions)}`)
         .replyOnce(200, JSON.stringify(responseData));
 
       return store.dispatch(searchEnterpriseList({ search: 'test-search-string' })).then(() => {
@@ -70,7 +69,6 @@ describe('actions', () => {
     it('dispatches failure action after fetching enrollments', () => {
       const store = mockStore();
       const options = {
-        permissions: 'enterprise_data_api_access',
         page: 2,
         page_size: 10,
         search: 'test-search-string',
@@ -92,7 +90,7 @@ describe('actions', () => {
         },
       ];
 
-      axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/with_access_to/?${qs.stringify(options)}`)
+      axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/dashboard_list/?${qs.stringify(options)}`)
         .networkError();
 
       return store.dispatch(searchEnterpriseList(options)).then(() => {

--- a/src/data/actions/portalConfiguration.test.js
+++ b/src/data/actions/portalConfiguration.test.js
@@ -37,7 +37,7 @@ describe('actions', () => {
       { type: FETCH_PORTAL_CONFIGURATION_SUCCESS, payload: { data: responseData } },
     ];
     const store = mockStore();
-    axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/with_access_to/?page=1&page_size=50&permissions=enterprise_data_api_access&slug=${slug}`)
+    axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/dashboard_list/?enterprise_slug=${slug}&page=1&page_size=50`)
       .replyOnce(200, JSON.stringify({ results: [responseData] }));
 
     return store.dispatch(fetchPortalConfiguration(slug)).then(() => {
@@ -53,7 +53,7 @@ describe('actions', () => {
     ];
     const store = mockStore();
 
-    axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/with_access_to/?page=1&page_size=50&permissions=enterprise_data_api_access&slug=${slug}`)
+    axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/dashboard_list/?enterprise_slug=${slug}&page=1&page_size=50`)
       .replyOnce(500, JSON.stringify({}));
 
     return store.dispatch(fetchPortalConfiguration(slug)).then(() => {

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -21,17 +21,16 @@ class LmsApiService {
 
   static fetchEnterpriseList(options) {
     const queryParams = {
-      permissions: 'enterprise_data_api_access',
       page: 1,
       page_size: 50,
       ...options,
     };
-    const enterpriseListUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/enterprise-customer/with_access_to/?${qs.stringify(queryParams)}`;
+    const enterpriseListUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/enterprise-customer/dashboard_list/?${qs.stringify(queryParams)}`;
     return apiClient.get(enterpriseListUrl);
   }
 
   static fetchEnterpriseBySlug(slug) {
-    return this.fetchEnterpriseList({ slug })
+    return this.fetchEnterpriseList({ enterprise_slug: slug })
       // Because we expect only one enterprise by slug we return only the first result
       .then((response) => {
         const { data } = response;


### PR DESCRIPTION
Per [ENT-1760](https://openedx.atlassian.net/browse/ENT-1760), we should replace our `with_access_to` calls with the new `dashboard_list` call. The response with both of these calls is the same; the `dashboard_list` endpoint uses the new permissions.

See the PR for the `dashboard_list` endpoint [here](https://github.com/edx/edx-enterprise/pull/444/files#diff-4495418c366e5831b5e2daaea415aa56R240). Also, I removed where we pass `{ permissions: 'enterprise_data_api_access' }` as the new endpoint does not check the permissions name.

Additionally, the `dashboard_list` endpoint looks for an `enterprise_slug` query parameter, where before we were passing `slug`. I've updated this as well to match what the endpoint expects.

**Important note: This PR should be merged AFTER we turn on the `enterprise_role_based_access_control` waffle switch!**
