### PR TITLE
Fix for null profileImage value

### DIFF
--- a/src/containers/Header/index.jsx
+++ b/src/containers/Header/index.jsx
@@ -4,15 +4,18 @@ import { fetchUserAccount, UserAccountApiService } from '@edx/frontend-auth';
 import apiClient from '../../data/apiClient';
 import Header from '../../components/Header';
 
-const mapStateToProps = state => ({
-  enterpriseName: state.portalConfiguration.enterpriseName,
-  enterpriseSlug: state.portalConfiguration.enterpriseSlug,
-  enterpriseLogo: state.portalConfiguration.enterpriseLogo,
-  email: state.userAccount.email,
-  username: state.authentication.username,
-  userProfileImageUrl: state.userAccount.profileImage.imageUrlMedium,
-  hasSidebarToggle: state.sidebar.hasSidebarToggle,
-});
+const mapStateToProps = (state) => {
+  const { userAccount: { profileImage } } = state;
+  return {
+    enterpriseName: state.portalConfiguration.enterpriseName,
+    enterpriseSlug: state.portalConfiguration.enterpriseSlug,
+    enterpriseLogo: state.portalConfiguration.enterpriseLogo,
+    email: state.userAccount.email,
+    username: state.authentication.username,
+    userProfileImageUrl: profileImage && profileImage.imageUrlMedium,
+    hasSidebarToggle: state.sidebar.hasSidebarToggle,
+  };
+};
 
 const mapDispatchToProps = (dispatch) => {
   const userAccountApiService = new UserAccountApiService(apiClient, process.env.LMS_BASE_URL);


### PR DESCRIPTION
Ticket: [ENT-1823](https://openedx.atlassian.net/browse/ENT-1823)

If a user authenticates with edx-portal but does not have `profileImage` set, we are currently throwing a JS error because we're trying to access a property of `profileImage`, which is `null`. This fix ensures `profileImage` exists before trying to access its properties, and avoids throwing the error.