### PR TITLE
Add `Assignments Remaining` column to Unassigned Table

### DIFF
--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -44,6 +44,10 @@ class CouponDetails extends React.Component {
           key: 'code',
         },
         {
+          label: 'Assignments Remaining',
+          key: 'assignments_remaining',
+        },
+        {
           label: 'Actions',
           key: 'actions',
         },
@@ -403,6 +407,18 @@ class CouponDetails extends React.Component {
       tableColumns.splice(getColumnIndexForKey('assigned_to'), 1);
     }
 
+    // `assignments_remaining` column
+    if (value === 'unassigned' && getColumnIndexForKey('assignments_remaining') === -1) {
+      // Add `assignments_remaining` column if it doesn't already exist.
+      tableColumns.splice(3, 0, {
+        label: 'Assignments Remaining',
+        key: 'assignments_remaining',
+      });
+    } else if (value !== 'unassigned' && getColumnIndexForKey('assignments_remaining') > -1) {
+      // Remove `assignments_remaining` column if it already exists.
+      tableColumns.splice(getColumnIndexForKey('assignments_remaining'), 1);
+    }
+
     // `actions` column
     if (value !== 'redeemed' && getColumnIndexForKey('actions') === -1) {
       // Add `actions` column if it doesn't already exist
@@ -565,6 +581,7 @@ class CouponDetails extends React.Component {
         </span>
       ) : code.assigned_to,
       redemptions: `${code.redemptions.used} of ${code.redemptions.total}`,
+      assignments_remaining: `${code.redemptions.total - code.redemptions.used - code.redemptions.num_assignments}`,
       actions: this.getActionButton(code),
       select: (
         <CheckBox

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -80,6 +80,7 @@ const sampleTableData = {
         redemptions: {
           total: 100,
           used: 100,
+          num_assignments: 0,
         },
       },
       {

--- a/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
+++ b/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
@@ -614,6 +614,12 @@ exports[`CouponDetailsWrapper renders with table data 1`] = `
                     className=""
                     scope="col"
                   >
+                    Assignments Remaining
+                  </th>
+                  <th
+                    className=""
+                    scope="col"
+                  >
                     Actions
                   </th>
                 </tr>
@@ -666,6 +672,11 @@ exports[`CouponDetailsWrapper renders with table data 1`] = `
                     className=""
                   >
                     test-code-1
+                  </td>
+                  <td
+                    className=""
+                  >
+                    85
                   </td>
                   <td
                     className=""
@@ -741,6 +752,11 @@ exports[`CouponDetailsWrapper renders with table data 1`] = `
                   </td>
                   <td
                     className=""
+                  >
+                    0
+                  </td>
+                  <td
+                    className=""
                   />
                 </tr>
                 <tr
@@ -788,6 +804,11 @@ exports[`CouponDetailsWrapper renders with table data 1`] = `
                     className=""
                   >
                     test-code-3
+                  </td>
+                  <td
+                    className=""
+                  >
+                    85
                   </td>
                   <td
                     className=""


### PR DESCRIPTION
The purpose of this PR is to add a new column `Assignments Remaining` to Unassigned Table that will display remaining assignments for each voucher code.

[ENT-1706](https://openedx.atlassian.net/browse/ENT-1706)