### PR TITLE
Show 404 page if no data is returned by API

### DIFF
--- a/src/components/Admin/Admin.test.jsx
+++ b/src/components/Admin/Admin.test.jsx
@@ -48,8 +48,34 @@ const AdminWrapper = props => (
 );
 
 describe('<Admin />', () => {
+  const baseProps = {
+    activeLearners: {
+      past_week: 1,
+      past_month: 1,
+    },
+    enrolledLearners: 1,
+    courseCompletions: 1,
+    lastUpdatedDate: '2018-07-31T23:14:35Z',
+    numberOfUsers: 3,
+  };
+
   describe('renders correctly', () => {
     it('calls fetchDashboardAnalytics prop', () => {
+      const mockFetchDashboardAnalytics = jest.fn();
+      const tree = renderer
+        .create((
+          <AdminWrapper
+            fetchDashboardAnalytics={mockFetchDashboardAnalytics}
+            enterpriseId="test-enterprise-id"
+            loading
+          />
+        ))
+        .toJSON();
+      expect(mockFetchDashboardAnalytics).toHaveBeenCalled();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('with no dashboard analytics data', () => {
       const mockFetchDashboardAnalytics = jest.fn();
       const tree = renderer
         .create((
@@ -64,17 +90,6 @@ describe('<Admin />', () => {
     });
 
     describe('with dashboard analytics data', () => {
-      const baseProps = {
-        activeLearners: {
-          past_week: 1,
-          past_month: 1,
-        },
-        enrolledLearners: 1,
-        courseCompletions: 1,
-        lastUpdatedDate: '2018-07-31T23:14:35Z',
-        numberOfUsers: 3,
-      };
-
       it('renders full report', () => {
         const tree = renderer
           .create((
@@ -295,7 +310,6 @@ describe('<Admin />', () => {
 
   describe('calls download csv fetch method for table', () => {
     let spy;
-
     const actionSlugs = {
       enrollments: {
         csvFetchMethod: 'fetchCourseEnrollments',
@@ -346,6 +360,7 @@ describe('<Admin />', () => {
         spy = jest.spyOn(EnterpriseDataApiService, actionMetadata.csvFetchMethod);
         const wrapper = mount((
           <AdminWrapper
+            {...baseProps}
             enterpriseId="test-enterprise-id"
             table={{
               [key]: {

--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -52,7 +52,13 @@ Array [
     >
       <div
         className="col"
-      />
+      >
+        <div
+          className="loading d-flex align-items-center justify-content-center overview mt-3"
+        >
+          Loading...
+        </div>
+      </div>
     </div>
     <div
       className="row mt-4"
@@ -73,32 +79,6 @@ Array [
       <div
         className="col"
       >
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 col-md-6 pt-1 pb-3"
-          />
-          <div
-            className="col-12 col-md-6 text-md-right"
-          >
-            <button
-              className="btn btn-outline-primary download-btn"
-              disabled={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              type="button"
-            >
-              <span
-                aria-hidden={true}
-                className="fa mr-2 fa-download"
-                id="Icon1"
-              />
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
         <div
           className="mt-3 mb-5"
         />
@@ -6124,4 +6104,28 @@ Array [
     </div>
   </div>,
 ]
+`;
+
+exports[`<Admin /> renders correctly with no dashboard analytics data 1`] = `
+<div
+  className="container-fluid mt-3"
+>
+  <div
+    className="text-center py-5"
+  >
+    <h1
+      className={null}
+    >
+      404
+    </h1>
+    <p
+      className="lead"
+    >
+      Oops, sorry we can't find that page!
+    </p>
+    <p>
+      Either something went wrong or the page doesn't exist anymore.
+    </p>
+  </div>
+</div>
 `;

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -16,6 +16,7 @@ import EnrolledLearnersForInactiveCoursesTable from '../EnrolledLearnersForInact
 import CompletedLearnersTable from '../CompletedLearnersTable';
 import PastWeekPassedLearnersTable from '../PastWeekPassedLearnersTable';
 import LearnerActivityTable from '../LearnerActivityTable';
+import NotFoundPage from '../NotFoundPage';
 
 import AdminCards from '../../containers/AdminCards';
 import DownloadCsvButton from '../../containers/DownloadCsvButton';
@@ -231,68 +232,72 @@ class Admin extends React.Component {
 
     return (
       <React.Fragment>
-        <Helmet>
-          <title>Learner and Progress Report</title>
-        </Helmet>
-        <Hero title="Learner and Progress Report" />
-        <div className="container-fluid">
-          <div className="row mt-4">
-            <div className="col">
-              <H2>Overview</H2>
-            </div>
-          </div>
-          <div className="row">
-            <div className="col">
-              {error && this.renderErrorMessage()}
-              {loading && this.renderLoadingMessage()}
-              {!loading && !error && this.hasAnalyticsData() &&
-                <AdminCards />
-              }
-            </div>
-          </div>
-          <div className="row mt-4">
-            <div className="col">
-              <H2 className="table-title">{tableMetadata.title}</H2>
-              {actionSlug && this.renderResetButton()}
-              {tableMetadata.subtitle && <H3>{tableMetadata.subtitle}</H3>}
-              {tableMetadata.description && <p>{tableMetadata.description}</p>}
-            </div>
-          </div>
-          <div className="row">
-            <div className="col">
-              {!error && !loading && !this.hasEmptyData() &&
-                <div className="row">
-                  <div className="col-12 col-md-6 pt-1 pb-3">
-                    {lastUpdatedDate &&
-                      <React.Fragment>
-                        Showing data as of {formatTimestamp({ timestamp: lastUpdatedDate })}
-                      </React.Fragment>
-                    }
-                  </div>
-                  <div className="col-12 col-md-6 text-md-right">
-                    <DownloadCsvButton
-                      id={tableMetadata.csvButtonId}
-                      fetchMethod={tableMetadata.csvFetchMethod}
-                      disabled={this.shouldDisableCsvButton(actionSlug)}
-                      buttonLabel={`Download ${actionSlug ? 'current' : 'full'} report (CSV)`}
-                    />
+        {!loading && !error && !this.hasAnalyticsData() ? <NotFoundPage /> : (
+          <React.Fragment>
+            <Helmet>
+              <title>Learner and Progress Report</title>
+            </Helmet>
+            <Hero title="Learner and Progress Report" />
+            <div className="container-fluid">
+              <div className="row mt-4">
+                <div className="col">
+                  <H2>Overview</H2>
+                </div>
+              </div>
+              <div className="row">
+                <div className="col">
+                  {error && this.renderErrorMessage()}
+                  {loading && this.renderLoadingMessage()}
+                  {!loading && !error && this.hasAnalyticsData() &&
+                    <AdminCards />
+                  }
+                </div>
+              </div>
+              <div className="row mt-4">
+                <div className="col">
+                  <H2 className="table-title">{tableMetadata.title}</H2>
+                  {actionSlug && this.renderResetButton()}
+                  {tableMetadata.subtitle && <H3>{tableMetadata.subtitle}</H3>}
+                  {tableMetadata.description && <p>{tableMetadata.description}</p>}
+                </div>
+              </div>
+              <div className="row">
+                <div className="col">
+                  {!error && !loading && !this.hasEmptyData() &&
+                    <div className="row">
+                      <div className="col-12 col-md-6 pt-1 pb-3">
+                        {lastUpdatedDate &&
+                          <React.Fragment>
+                            Showing data as of {formatTimestamp({ timestamp: lastUpdatedDate })}
+                          </React.Fragment>
+                        }
+                      </div>
+                      <div className="col-12 col-md-6 text-md-right">
+                        <DownloadCsvButton
+                          id={tableMetadata.csvButtonId}
+                          fetchMethod={tableMetadata.csvFetchMethod}
+                          disabled={this.shouldDisableCsvButton(actionSlug)}
+                          buttonLabel={`Download ${actionSlug ? 'current' : 'full'} report (CSV)`}
+                        />
+                      </div>
+                    </div>
+                  }
+                  {csvErrorMessage && this.renderCsvErrorMessage(csvErrorMessage)}
+                  <div className="mt-3 mb-5">
+                    {enterpriseId && tableMetadata.component}
                   </div>
                 </div>
-              }
-              {csvErrorMessage && this.renderCsvErrorMessage(csvErrorMessage)}
-              <div className="mt-3 mb-5">
-                {enterpriseId && tableMetadata.component}
+              </div>
+              <div className="row">
+                <div className="col">
+                  <p>
+                    For more information, contact edX Enterprise Support at <MailtoLink to="customersuccess@edx.org" content=" customersuccess@edx.org" />.
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-          <div className="row">
-            <div className="col">
-              <p>
-                For more information, contact edX Enterprise Support at <MailtoLink to="customersuccess@edx.org" content=" customersuccess@edx.org" />.
-              </p>
-            </div>
-          </div>
-        </div>
+          </React.Fragment>
+        )}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
On Admin Dashboard, if no analytics data is returned by the API, we will show a `404` page. 

This handles both the scenarios where an invalid enterprise id is supplied in url (slug) or user does not have the access. In both cases, API sends no results in the response, hence a `404` page will be shown to them.

[ENT-1830](https://openedx.atlassian.net/browse/ENT-1830)