### PR TITLE
Replace 404 with loading component

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -6121,24 +6121,8 @@ Array [
 
 exports[`<Admin /> renders correctly with no dashboard analytics data 1`] = `
 <div
-  className="container-fluid mt-3"
+  className="loading d-flex align-items-center justify-content-center overview mt-3"
 >
-  <div
-    className="text-center py-5"
-  >
-    <h1
-      className={null}
-    >
-      404
-    </h1>
-    <p
-      className="lead"
-    >
-      Oops, sorry we can't find that page!
-    </p>
-    <p>
-      Either something went wrong or the page doesn't exist anymore.
-    </p>
-  </div>
+  Loading...
 </div>
 `;

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -16,7 +16,6 @@ import EnrolledLearnersForInactiveCoursesTable from '../EnrolledLearnersForInact
 import CompletedLearnersTable from '../CompletedLearnersTable';
 import PastWeekPassedLearnersTable from '../PastWeekPassedLearnersTable';
 import LearnerActivityTable from '../LearnerActivityTable';
-import NotFoundPage from '../NotFoundPage';
 
 import AdminCards from '../../containers/AdminCards';
 import DownloadCsvButton from '../../containers/DownloadCsvButton';
@@ -232,7 +231,7 @@ class Admin extends React.Component {
 
     return (
       <React.Fragment>
-        {!loading && !error && !this.hasAnalyticsData() ? <NotFoundPage /> : (
+        {!loading && !error && !this.hasAnalyticsData() ? this.renderLoadingMessage() : (
           <React.Fragment>
             <Helmet>
               <title>Learner and Progress Report</title>


### PR DESCRIPTION
Replace the 404 component flash with a loading component instead. This does create a situation where 2 loading screens are show in a row if the root url of the portal is hit and the user is only authorized for a single enterprise.