### PR TITLE
Add code search UI functionality

### DIFF
--- a/src/components/ActionButtonWithModal/index.jsx
+++ b/src/components/ActionButtonWithModal/index.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { Button } from '@edx/paragon';
+
+class ActionButtonWithModal extends React.Component {
+  state = {
+    isModalOpen: false,
+  };
+
+  setIsModalOpen = isModalOpen => this.setState({ isModalOpen });
+
+  render() {
+    const { buttonClassName, buttonLabel, renderModal } = this.props;
+    const { isModalOpen } = this.state;
+    return (
+      <React.Fragment>
+        <Button
+          className={classNames(buttonClassName, 'btn-link btn-sm p-0')}
+          onClick={() => this.setIsModalOpen(true)}
+        >
+          {buttonLabel}
+        </Button>
+        {isModalOpen && renderModal({
+          closeModal: () => this.setIsModalOpen(false),
+        })}
+      </React.Fragment>
+    );
+  }
+}
+
+ActionButtonWithModal.propTypes = {
+  buttonLabel: PropTypes.string.isRequired,
+  buttonClassName: PropTypes.string.isRequired,
+  renderModal: PropTypes.func.isRequired,
+};
+
+export default ActionButtonWithModal;

--- a/src/components/CodeManagement/CodeManagement.scss
+++ b/src/components/CodeManagement/CodeManagement.scss
@@ -1,0 +1,12 @@
+@import "~@edx/paragon/scss/edx/utilities-only";
+
+.search-field {
+  @extend .mr-2;
+
+  label {
+    @extend .font-weight-normal;
+  }
+  input[type='search'] {
+    padding: 0 0 3px 0;
+  }
+}

--- a/src/components/CodeManagement/index.jsx
+++ b/src/components/CodeManagement/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 import Helmet from 'react-helmet';
 import qs from 'query-string';
@@ -10,8 +11,12 @@ import Hero from '../Hero';
 import Coupon from '../Coupon';
 import LoadingMessage from '../LoadingMessage';
 import StatusAlert from '../StatusAlert';
+import SearchBar from '../SearchBar';
+import CodeSearchResults from '../CodeSearchResults';
 
 import { updateUrl } from '../../utils';
+
+import './CodeManagement.scss';
 
 class CodeManagement extends React.Component {
   constructor(props) {
@@ -20,6 +25,7 @@ class CodeManagement extends React.Component {
     this.couponRefs = [];
     this.state = {
       hasRequestedCodes: false,
+      searchQuery: '',
     };
 
     this.handleRefreshData = this.handleRefreshData.bind(this);
@@ -125,20 +131,21 @@ class CodeManagement extends React.Component {
   handleRefreshData() {
     this.paginateCouponOrders(1);
     this.removeQueryParams(['coupon_id', 'page', 'overview_page']);
+    this.setState({ searchQuery: '' });
   }
 
   handleCouponExpand(selectedIndex) {
     const { location } = this.props;
     const queryParams = qs.parse(location.search);
-
     const coupons = this.getCouponRefs();
     const selectedCoupon = coupons[selectedIndex];
     const couponId = selectedCoupon.props.data.id;
 
     queryParams.coupon_id = couponId;
-    updateUrl(queryParams);
 
+    updateUrl(queryParams);
     this.setCouponOpacity(couponId);
+    this.setState({ searchQuery: '' });
   }
 
   handleCouponCollapse() {
@@ -232,8 +239,8 @@ class CodeManagement extends React.Component {
       loading,
       match,
     } = this.props;
-    const { hasRequestedCodes } = this.state;
-
+    const { hasRequestedCodes, searchQuery } = this.state;
+    const hasSearchQuery = !!searchQuery;
     return (
       <React.Fragment>
         <Helmet>
@@ -242,11 +249,25 @@ class CodeManagement extends React.Component {
         <Hero title="Code Management" />
         <div className="container-fluid">
           {hasRequestedCodes && this.renderRequestCodesSuccessMessage()}
-          <div className="row mt-4 mb-3">
-            <div className="col-12 col-md-3 mb-2 mb-md-0">
+          <div className="row mt-4 mb-3 no-gutters">
+            <div className="col-12 col-xl-3 mb-3 mb-xl-0">
               <H2>Overview</H2>
             </div>
-            <div className="col-12 col-md-9 mb-2 mb-md-0 text-md-right">
+            <div className="col-12 col-xl-4 mb-3 mb-xl-0 offset-xl-1">
+              <SearchBar
+                inputLabel="Search by email:"
+                onSearch={(query) => {
+                  this.setState({ searchQuery: query });
+                  this.removeQueryParams(['coupon_id', 'page']);
+                }}
+                onClear={() => {
+                  this.setState({ searchQuery: '' });
+                  this.removeQueryParams(['page']);
+                }}
+                value={searchQuery}
+              />
+            </div>
+            <div className="col-12 col-xl-4 mb-3 mb-xl-0 text-xl-right">
               <Button
                 className="mr-2 btn-link"
                 onClick={this.handleRefreshData}
@@ -266,6 +287,24 @@ class CodeManagement extends React.Component {
                   Request more codes
                 </React.Fragment>
               </Link>
+            </div>
+          </div>
+          <div className="row">
+            <div
+              className={classNames(
+                'col',
+                {
+                  'mt-2 mb-4': hasSearchQuery,
+                },
+              )}
+            >
+              <CodeSearchResults
+                isOpen={hasSearchQuery}
+                searchQuery={searchQuery}
+                onClose={() => {
+                  this.setState({ searchQuery: '' });
+                }}
+              />
             </div>
           </div>
           <div className="row">

--- a/src/components/CodeReminderModal/index.jsx
+++ b/src/components/CodeReminderModal/index.jsx
@@ -56,7 +56,6 @@ class CodeReminderModal extends React.Component {
       data: { selectedCodes },
       couponDetailsTable: { data: tableData },
     } = this.props;
-
     let numberOfSelectedCodes = 0;
     if (selectedCodes && selectedCodes.length) {
       numberOfSelectedCodes = selectedCodes.length;
@@ -228,7 +227,7 @@ class CodeReminderModal extends React.Component {
           buttons={[
             <Button
               disabled={submitting}
-              className="btn-primary"
+              className="code-remind-save-btn btn-primary"
               onClick={handleSubmit(this.handleModalSubmit)}
             >
               <React.Fragment>
@@ -250,6 +249,7 @@ CodeReminderModal.defaultProps = {
   isBulkRemind: false,
   data: {},
   selectedToggle: null,
+  couponDetailsTable: {},
 };
 
 CodeReminderModal.propTypes = {
@@ -270,7 +270,7 @@ CodeReminderModal.propTypes = {
     data: PropTypes.shape({
       count: PropTypes.number,
     }),
-  }).isRequired,
+  }),
   isBulkRemind: PropTypes.bool,
   selectedToggle: PropTypes.string,
   data: PropTypes.shape({}),
@@ -281,5 +281,4 @@ export default reduxForm({
   initialValues: {
     'email-template': emailTemplate,
   },
-
 })(CodeReminderModal);

--- a/src/components/CodeRevokeModal/index.jsx
+++ b/src/components/CodeRevokeModal/index.jsx
@@ -215,7 +215,7 @@ class CodeRevokeModal extends React.Component {
           buttons={[
             <Button
               disabled={submitting}
-              className="btn-primary"
+              className="code-revoke-save-btn btn-primary"
               onClick={handleSubmit(this.handleModalSubmit)}
             >
               <React.Fragment>
@@ -257,9 +257,8 @@ CodeRevokeModal.propTypes = {
 };
 
 export default reduxForm({
-  form: 'assignment-revoke-modal-form',
+  form: 'code-revoke-modal-form',
   initialValues: {
     'email-template': emailTemplate,
   },
-
 })(CodeRevokeModal);

--- a/src/components/CodeSearchResults/CodeSearchResults.scss
+++ b/src/components/CodeSearchResults/CodeSearchResults.scss
@@ -1,0 +1,20 @@
+@import "~@edx/paragon/scss/edx/utilities-only";
+
+.code-search-results {
+  .loading {
+    @extend .mb-3;
+    height: 220px;
+  }
+  .table {
+    @extend .bg-white;
+    td {
+        vertical-align: middle;
+    }
+  }
+  .pagination {
+    @extend .mb-0;
+    button {
+      font-size: 0.875rem;
+    }
+  }
+}

--- a/src/components/CodeSearchResults/CodeSearchResults.test.jsx
+++ b/src/components/CodeSearchResults/CodeSearchResults.test.jsx
@@ -1,0 +1,340 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+import { mount } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import CodeSearchResults from './index';
+
+import EcommerceApiService from '../../data/services/EcommerceApiService';
+
+jest.mock('../../data/services/EcommerceApiService');
+
+const mockStore = configureMockStore([thunk]);
+const getMockStore = store => mockStore(store);
+const initialStore = {
+  table: {},
+};
+
+describe('<CodeSearchResults />', () => {
+  beforeAll(() => {
+    const mockPromiseResolve = () => Promise.resolve({ data: {} });
+    EcommerceApiService.fetchCodeSearchResults.mockImplementation(mockPromiseResolve);
+    EcommerceApiService.sendCodeReminder.mockImplementation(mockPromiseResolve);
+    EcommerceApiService.sendCodeRevoke.mockImplementation(mockPromiseResolve);
+  });
+
+  describe('basic rendering', () => {
+    it('should render nothing visible when isOpen prop is false', () => {
+      const store = getMockStore({ ...initialStore });
+      const tree = renderer
+        .create((
+          <MemoryRouter>
+            <Provider store={store}>
+              <CodeSearchResults
+                onClose={jest.fn()}
+                searchQuery="test@test.com"
+              />
+            </Provider>
+          </MemoryRouter>
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render email validation error when searchQuery is invalid email address', () => {
+      const store = getMockStore({ ...initialStore });
+      const tree = renderer
+        .create((
+          <MemoryRouter>
+            <Provider store={store}>
+              <CodeSearchResults
+                onClose={jest.fn()}
+                searchQuery="invalid_email"
+                isOpen
+              />
+            </Provider>
+          </MemoryRouter>
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render loading', () => {
+      const store = getMockStore({
+        ...initialStore,
+        table: {
+          'code-search-results': {
+            loading: true,
+            error: null,
+            data: null,
+          },
+        },
+      });
+      const tree = renderer
+        .create((
+          <MemoryRouter>
+            <Provider store={store}>
+              <CodeSearchResults
+                onClose={jest.fn()}
+                searchQuery="test@test.com"
+                isOpen
+              />
+            </Provider>
+          </MemoryRouter>
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render table data', () => {
+      const store = getMockStore({
+        ...initialStore,
+        table: {
+          'code-search-results': {
+            loading: false,
+            error: null,
+            data: {
+              current_page: 1,
+              num_pages: 1,
+              results: [{
+                id: 1,
+                coupon_id: 1,
+                coupon_name: 'Test Coupon Name',
+                redemptions_and_assignments: [{
+                  code: 'Y7XS3OGG7WB7KQ5R',
+                  course_key: 'test-course-key',
+                  course_title: 'Test Course Title',
+                  redeemed_date: '2019-08-28',
+                }],
+              }, {
+                id: 2,
+                coupon_id: 2,
+                coupon_name: 'Test Coupon Name 2',
+                redemptions_and_assignments: [{
+                  code: 'CMX9N1LPGTUSL7DU',
+                  course_key: null,
+                  course_title: null,
+                  redeemed_date: null,
+                }],
+              }, {
+                id: 3,
+                coupon_id: 1,
+                coupon_name: 'Test Coupon Name',
+                redemptions_and_assignments: [{
+                  code: 'Y7XS3OGG7WB7KQ5R',
+                  course_key: 'test-course-key',
+                  course_title: 'Test Course Title',
+                  redeemed_date: '2019-08-30',
+                }, {
+                  code: 'FAG2LVLNHAKIXQ0Q',
+                  course_key: null,
+                  course_title: null,
+                  redeemed_date: null,
+                }],
+              }],
+            },
+          },
+        },
+      });
+      const tree = renderer
+        .create((
+          <MemoryRouter>
+            <Provider store={store}>
+              <CodeSearchResults
+                onClose={jest.fn()}
+                searchQuery="test@test.com"
+                isOpen
+              />
+            </Provider>
+          </MemoryRouter>
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render empty table data', () => {
+      const store = getMockStore({
+        ...initialStore,
+        table: {
+          'code-search-results': {
+            loading: false,
+            error: null,
+            data: {
+              current_page: 1,
+              num_pages: 1,
+              results: [],
+            },
+          },
+        },
+      });
+      const tree = renderer
+        .create((
+          <MemoryRouter>
+            <Provider store={store}>
+              <CodeSearchResults
+                onClose={jest.fn()}
+                searchQuery="test@test.com"
+                isOpen
+              />
+            </Provider>
+          </MemoryRouter>
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render error', () => {
+      const store = getMockStore({
+        ...initialStore,
+        table: {
+          'code-search-results': {
+            loading: false,
+            error: new Error('Network Error'),
+            data: null,
+          },
+        },
+      });
+      const tree = renderer
+        .create((
+          <MemoryRouter>
+            <Provider store={store}>
+              <CodeSearchResults
+                onClose={jest.fn()}
+                searchQuery="test@test.com"
+                isOpen
+              />
+            </Provider>
+          </MemoryRouter>
+        ))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('action buttons', () => {
+    const flushPromises = () => new Promise(setImmediate);
+
+    it('should handle remind button', async () => {
+      const store = getMockStore({
+        ...initialStore,
+        table: {
+          'code-search-results': {
+            loading: false,
+            error: null,
+            data: {
+              current_page: 1,
+              num_pages: 1,
+              results: [{
+                id: 1,
+                coupon_id: 10,
+                coupon_name: 'Test Coupon Name',
+                redemptions_and_assignments: [{
+                  code: 'Y7XS3OGG7WB7KQ5R',
+                  course_key: null,
+                  course_title: null,
+                  redeemed_date: null,
+                }],
+              }],
+            },
+          },
+        },
+      });
+      const wrapper = mount((
+        <MemoryRouter>
+          <Provider store={store}>
+            <CodeSearchResults
+              onClose={jest.fn()}
+              searchQuery="test@test.com"
+              isOpen
+            />
+          </Provider>
+        </MemoryRouter>
+      ));
+      expect(wrapper.find('CodeSearchResults').state('isCodeReminderSuccessful')).toBeFalsy();
+      wrapper.find('RemindButton').simulate('click');
+      wrapper.find('CodeReminderModal').find('.code-remind-save-btn').first().simulate('click');
+      await flushPromises();
+      wrapper.update();
+      expect(wrapper.find('CodeSearchResults').state('isCodeReminderSuccessful')).toBeTruthy();
+    });
+
+    it('should handle revoke button', async () => {
+      const store = getMockStore({
+        ...initialStore,
+        table: {
+          'code-search-results': {
+            loading: false,
+            error: null,
+            data: {
+              current_page: 1,
+              num_pages: 1,
+              results: [{
+                id: 1,
+                coupon_id: 10,
+                coupon_name: 'Test Coupon Name',
+                redemptions_and_assignments: [{
+                  code: 'Y7XS3OGG7WB7KQ5R',
+                  course_key: null,
+                  course_title: null,
+                  redeemed_date: null,
+                }],
+              }],
+            },
+          },
+        },
+      });
+      const wrapper = mount((
+        <MemoryRouter>
+          <Provider store={store}>
+            <CodeSearchResults
+              onClose={jest.fn()}
+              searchQuery="test@test.com"
+              isOpen
+            />
+          </Provider>
+        </MemoryRouter>
+      ));
+      expect(wrapper.find('CodeSearchResults').state('isCodeRevokeSuccessful')).toBeFalsy();
+      wrapper.find('RevokeButton').simulate('click');
+      wrapper.find('CodeRevokeModal').find('.code-revoke-save-btn').first().simulate('click');
+      await flushPromises();
+      wrapper.update();
+      expect(wrapper.find('CodeSearchResults').state('isCodeRevokeSuccessful')).toBeTruthy();
+    });
+  });
+
+  it('should handle close button click', () => {
+    const mockOnClose = jest.fn();
+    const store = getMockStore({
+      ...initialStore,
+      table: {
+        'code-search-results': {
+          loading: false,
+          error: null,
+          data: {
+            current_page: 1,
+            num_pages: 1,
+            results: [],
+          },
+        },
+      },
+    });
+    const wrapper = mount((
+      <MemoryRouter>
+        <Provider store={store}>
+          <CodeSearchResults
+            onClose={mockOnClose}
+            searchQuery="test@test.com"
+            isOpen
+          />
+        </Provider>
+      </MemoryRouter>
+    ));
+
+    wrapper.find('.close-search-results-btn').first().simulate('click');
+    expect(mockOnClose).toBeCalledTimes(1);
+  });
+});

--- a/src/components/CodeSearchResults/CodeSearchResultsHeading.jsx
+++ b/src/components/CodeSearchResults/CodeSearchResultsHeading.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Icon } from '@edx/paragon';
+
+const CodeSearchResultsHeading = ({ searchQuery, onClose }) => (
+  <div className="d-flex align-items-center justify-content-between mb-3">
+    <div className="flex-grow-1 text-truncate mr-3">
+      <h3 className="lead m-0 text-truncate">
+        Search results for <em>&quot;{searchQuery}&quot;</em>
+      </h3>
+    </div>
+    <div className="flex-grow-0 flex-shrink-0">
+      <Button
+        className="close-search-results-btn btn-outline-primary"
+        onClick={onClose}
+      >
+        <Icon className="fa fa-times mr-2" />
+          Close search results
+      </Button>
+    </div>
+  </div>
+);
+
+CodeSearchResultsHeading.propTypes = {
+  searchQuery: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default CodeSearchResultsHeading;

--- a/src/components/CodeSearchResults/CodeSearchResultsTable.jsx
+++ b/src/components/CodeSearchResults/CodeSearchResultsTable.jsx
@@ -37,14 +37,15 @@ const tableColumns = [
 ];
 
 /**
- * The search API response contains a record for each coupon batch a
- * user is associated with (i.e., has unused assignments, or actual
- * redemptions). Under each coupon batch is an array of assignments and
- * redemptiions, that contains all the metadata associated with a redemption,
- * if applicable. Because we want the search results UI to show a row
- * for each unused assignment and all redeemed courses associated with a
- * particular user, this function flattens the search results by creating
- * a new table row for each value in `redemptions_and_assignments`.
+ * The search API response contains records for all vouchers a user is associated
+ * with (i.e., has unused assignments, or actual redemptions). To get a complete
+ * grouping of assignments or redemptions for a particular coupon batch for the
+ * user, we need to combine the results in `assignments_and_redemptions` (which
+ * contains all the metadata associated with a redemption, if applicable) for
+ * all vouchers that share the same `coupon_id` field. Because we want the search
+ * results UI to show a row for each unused assignment and all redeemed courses
+ * associated with a particular user, this function flattens the search results by
+ * created a new table row for each value in the `redemptions_and_assignments` fields.
  */
 const transformSearchResults = (items) => {
   const itemsSortedByCouponId = items.sort((itemA, itemB) => itemA.coupon_id - itemB.coupon_id);

--- a/src/components/CodeSearchResults/__snapshots__/CodeSearchResults.test.jsx.snap
+++ b/src/components/CodeSearchResults/__snapshots__/CodeSearchResults.test.jsx.snap
@@ -20,13 +20,13 @@ exports[`<CodeSearchResults /> basic rendering should render email validation er
       className="code-search-results border-bottom pb-4"
     >
       <div
-        className="row mb-3"
+        className="d-flex align-items-center justify-content-between mb-3"
       >
         <div
-          className="col-12 col-md-8"
+          className="flex-grow-1 text-truncate mr-3"
         >
           <h3
-            className="lead m-0 mb-2 mb-md-0"
+            className="lead m-0 text-truncate"
           >
             Search results for 
             <em>
@@ -37,7 +37,7 @@ exports[`<CodeSearchResults /> basic rendering should render email validation er
           </h3>
         </div>
         <div
-          className="col text-md-right"
+          className="flex-grow-0 flex-shrink-0"
         >
           <button
             className="btn close-search-results-btn btn-outline-primary"
@@ -108,13 +108,13 @@ exports[`<CodeSearchResults /> basic rendering should render empty table data 1`
       className="code-search-results border-bottom pb-4"
     >
       <div
-        className="row mb-3"
+        className="d-flex align-items-center justify-content-between mb-3"
       >
         <div
-          className="col-12 col-md-8"
+          className="flex-grow-1 text-truncate mr-3"
         >
           <h3
-            className="lead m-0 mb-2 mb-md-0"
+            className="lead m-0 text-truncate"
           >
             Search results for 
             <em>
@@ -125,7 +125,7 @@ exports[`<CodeSearchResults /> basic rendering should render empty table data 1`
           </h3>
         </div>
         <div
-          className="col text-md-right"
+          className="flex-grow-0 flex-shrink-0"
         >
           <button
             className="btn close-search-results-btn btn-outline-primary"
@@ -196,13 +196,13 @@ exports[`<CodeSearchResults /> basic rendering should render error 1`] = `
       className="code-search-results border-bottom pb-4"
     >
       <div
-        className="row mb-3"
+        className="d-flex align-items-center justify-content-between mb-3"
       >
         <div
-          className="col-12 col-md-8"
+          className="flex-grow-1 text-truncate mr-3"
         >
           <h3
-            className="lead m-0 mb-2 mb-md-0"
+            className="lead m-0 text-truncate"
           >
             Search results for 
             <em>
@@ -213,7 +213,7 @@ exports[`<CodeSearchResults /> basic rendering should render error 1`] = `
           </h3>
         </div>
         <div
-          className="col text-md-right"
+          className="flex-grow-0 flex-shrink-0"
         >
           <button
             className="btn close-search-results-btn btn-outline-primary"
@@ -289,13 +289,13 @@ exports[`<CodeSearchResults /> basic rendering should render loading 1`] = `
       className="code-search-results border-bottom pb-4"
     >
       <div
-        className="row mb-3"
+        className="d-flex align-items-center justify-content-between mb-3"
       >
         <div
-          className="col-12 col-md-8"
+          className="flex-grow-1 text-truncate mr-3"
         >
           <h3
-            className="lead m-0 mb-2 mb-md-0"
+            className="lead m-0 text-truncate"
           >
             Search results for 
             <em>
@@ -306,7 +306,7 @@ exports[`<CodeSearchResults /> basic rendering should render loading 1`] = `
           </h3>
         </div>
         <div
-          className="col text-md-right"
+          className="flex-grow-0 flex-shrink-0"
         >
           <button
             className="btn close-search-results-btn btn-outline-primary"
@@ -365,13 +365,13 @@ exports[`<CodeSearchResults /> basic rendering should render table data 1`] = `
       className="code-search-results border-bottom pb-4"
     >
       <div
-        className="row mb-3"
+        className="d-flex align-items-center justify-content-between mb-3"
       >
         <div
-          className="col-12 col-md-8"
+          className="flex-grow-1 text-truncate mr-3"
         >
           <h3
-            className="lead m-0 mb-2 mb-md-0"
+            className="lead m-0 text-truncate"
           >
             Search results for 
             <em>
@@ -382,7 +382,7 @@ exports[`<CodeSearchResults /> basic rendering should render table data 1`] = `
           </h3>
         </div>
         <div
-          className="col text-md-right"
+          className="flex-grow-0 flex-shrink-0"
         >
           <button
             className="btn close-search-results-btn btn-outline-primary"

--- a/src/components/CodeSearchResults/__snapshots__/CodeSearchResults.test.jsx.snap
+++ b/src/components/CodeSearchResults/__snapshots__/CodeSearchResults.test.jsx.snap
@@ -1,0 +1,758 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CodeSearchResults /> basic rendering should render email validation error when searchQuery is invalid email address 1`] = `
+<div
+  className="pgn-transition-replace-group position-relative"
+  style={
+    Object {
+      "height": null,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "padding": ".1px 0",
+      }
+    }
+  >
+    <div
+      className="code-search-results border-bottom pb-4"
+    >
+      <div
+        className="row mb-3"
+      >
+        <div
+          className="col-12 col-md-8"
+        >
+          <h3
+            className="lead m-0 mb-2 mb-md-0"
+          >
+            Search results for 
+            <em>
+              "
+              invalid_email
+              "
+            </em>
+          </h3>
+        </div>
+        <div
+          className="col text-md-right"
+        >
+          <button
+            className="btn close-search-results-btn btn-outline-primary"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              aria-hidden={true}
+              className="fa fa-times mr-2"
+              id="Icon2"
+            />
+            Close search results
+          </button>
+        </div>
+      </div>
+      <div
+        className="alert fade alert-danger show"
+        hidden={false}
+        role="alert"
+      >
+        <div
+          className="alert-dialog"
+        >
+          <div
+            className="d-flex"
+          >
+            <div
+              className="icon mr-2"
+            >
+              <span
+                aria-hidden={true}
+                className="fa fa-exclamation-circle"
+                id="Icon3"
+              />
+            </div>
+            <div
+              className="message"
+            >
+              Please enter a valid email address in your search.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CodeSearchResults /> basic rendering should render empty table data 1`] = `
+<div
+  className="pgn-transition-replace-group position-relative"
+  style={
+    Object {
+      "height": null,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "padding": ".1px 0",
+      }
+    }
+  >
+    <div
+      className="code-search-results border-bottom pb-4"
+    >
+      <div
+        className="row mb-3"
+      >
+        <div
+          className="col-12 col-md-8"
+        >
+          <h3
+            className="lead m-0 mb-2 mb-md-0"
+          >
+            Search results for 
+            <em>
+              "
+              test@test.com
+              "
+            </em>
+          </h3>
+        </div>
+        <div
+          className="col text-md-right"
+        >
+          <button
+            className="btn close-search-results-btn btn-outline-primary"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              aria-hidden={true}
+              className="fa fa-times mr-2"
+              id="Icon10"
+            />
+            Close search results
+          </button>
+        </div>
+      </div>
+      <div
+        className="alert fade alert-warning show"
+        hidden={false}
+        role="alert"
+      >
+        <div
+          className="alert-dialog"
+        >
+          <div
+            className="d-flex"
+          >
+            <div
+              className="icon mr-2"
+            >
+              <span
+                aria-hidden={true}
+                className="fa fa-exclamation-circle"
+                id="Icon11"
+              />
+            </div>
+            <div
+              className="message"
+            >
+              There are no results.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CodeSearchResults /> basic rendering should render error 1`] = `
+<div
+  className="pgn-transition-replace-group position-relative"
+  style={
+    Object {
+      "height": null,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "padding": ".1px 0",
+      }
+    }
+  >
+    <div
+      className="code-search-results border-bottom pb-4"
+    >
+      <div
+        className="row mb-3"
+      >
+        <div
+          className="col-12 col-md-8"
+        >
+          <h3
+            className="lead m-0 mb-2 mb-md-0"
+          >
+            Search results for 
+            <em>
+              "
+              test@test.com
+              "
+            </em>
+          </h3>
+        </div>
+        <div
+          className="col text-md-right"
+        >
+          <button
+            className="btn close-search-results-btn btn-outline-primary"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              aria-hidden={true}
+              className="fa fa-times mr-2"
+              id="Icon12"
+            />
+            Close search results
+          </button>
+        </div>
+      </div>
+      <div
+        className="alert fade alert-danger show"
+        hidden={false}
+        role="alert"
+      >
+        <div
+          className="alert-dialog"
+        >
+          <div
+            className="d-flex"
+          >
+            <div
+              className="icon mr-2"
+            >
+              <span
+                aria-hidden={true}
+                className="fa fa-times-circle"
+                id="Icon13"
+              />
+            </div>
+            <div
+              className="message"
+            >
+              <span
+                className="title"
+              >
+                Unable to load data
+              </span>
+              Try refreshing your screen (Network Error)
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CodeSearchResults /> basic rendering should render loading 1`] = `
+<div
+  className="pgn-transition-replace-group position-relative"
+  style={
+    Object {
+      "height": null,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "padding": ".1px 0",
+      }
+    }
+  >
+    <div
+      className="code-search-results border-bottom pb-4"
+    >
+      <div
+        className="row mb-3"
+      >
+        <div
+          className="col-12 col-md-8"
+        >
+          <h3
+            className="lead m-0 mb-2 mb-md-0"
+          >
+            Search results for 
+            <em>
+              "
+              test@test.com
+              "
+            </em>
+          </h3>
+        </div>
+        <div
+          className="col text-md-right"
+        >
+          <button
+            className="btn close-search-results-btn btn-outline-primary"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              aria-hidden={true}
+              className="fa fa-times mr-2"
+              id="Icon4"
+            />
+            Close search results
+          </button>
+        </div>
+      </div>
+      <div
+        className="loading d-flex align-items-center justify-content-center table-loading"
+      >
+        Loading...
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CodeSearchResults /> basic rendering should render nothing visible when isOpen prop is false 1`] = `
+<div
+  className="pgn-transition-replace-group position-relative"
+  style={
+    Object {
+      "height": null,
+    }
+  }
+/>
+`;
+
+exports[`<CodeSearchResults /> basic rendering should render table data 1`] = `
+<div
+  className="pgn-transition-replace-group position-relative"
+  style={
+    Object {
+      "height": null,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "padding": ".1px 0",
+      }
+    }
+  >
+    <div
+      className="code-search-results border-bottom pb-4"
+    >
+      <div
+        className="row mb-3"
+      >
+        <div
+          className="col-12 col-md-8"
+        >
+          <h3
+            className="lead m-0 mb-2 mb-md-0"
+          >
+            Search results for 
+            <em>
+              "
+              test@test.com
+              "
+            </em>
+          </h3>
+        </div>
+        <div
+          className="col text-md-right"
+        >
+          <button
+            className="btn close-search-results-btn btn-outline-primary"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              aria-hidden={true}
+              className="fa fa-times mr-2"
+              id="Icon5"
+            />
+            Close search results
+          </button>
+        </div>
+      </div>
+      <div
+        className="code-search-results-table"
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col"
+          >
+            <div
+              className="table-responsive"
+            >
+              <table
+                className="table table-sm table-striped"
+              >
+                <thead
+                  className=""
+                >
+                  <tr
+                    className=""
+                  >
+                    <th
+                      className=""
+                      scope="col"
+                    >
+                      Coupon Batch
+                    </th>
+                    <th
+                      className=""
+                      scope="col"
+                    >
+                      Code
+                    </th>
+                    <th
+                      className=""
+                      scope="col"
+                    >
+                      Redeemed
+                    </th>
+                    <th
+                      className=""
+                      scope="col"
+                    >
+                      Redemption Date
+                    </th>
+                    <th
+                      className=""
+                      scope="col"
+                    >
+                      Course Title
+                    </th>
+                    <th
+                      className=""
+                      scope="col"
+                    >
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  className=""
+                >
+                  <tr
+                    className=""
+                  >
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      Test Coupon Name
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      Y7XS3OGG7WB7KQ5R
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-check text-primary"
+                        id="Icon6"
+                      />
+                      <span
+                        className="sr-only"
+                      >
+                        has been redeemed
+                      </span>
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      August 28, 2019
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      Test Course Title
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      -
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                  >
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      Test Coupon Name
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      Y7XS3OGG7WB7KQ5R
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-check text-primary"
+                        id="Icon7"
+                      />
+                      <span
+                        className="sr-only"
+                      >
+                        has been redeemed
+                      </span>
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      August 30, 2019
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      Test Course Title
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      -
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                  >
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      Test Coupon Name
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      FAG2LVLNHAKIXQ0Q
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      -
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      -
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      -
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      <button
+                        className="btn remind-btn btn-link btn-sm p-0"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        type="button"
+                      >
+                        Remind
+                      </button>
+                       | 
+                      <button
+                        className="btn revoke-btn btn-link btn-sm p-0"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        type="button"
+                      >
+                        Revoke
+                      </button>
+                    </td>
+                  </tr>
+                  <tr
+                    className=""
+                  >
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      Test Coupon Name 2
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      CMX9N1LPGTUSL7DU
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      -
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      -
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      -
+                    </td>
+                    <td
+                      className=""
+                      scope={null}
+                    >
+                      <button
+                        className="btn remind-btn btn-link btn-sm p-0"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        type="button"
+                      >
+                        Remind
+                      </button>
+                       | 
+                      <button
+                        className="btn revoke-btn btn-link btn-sm p-0"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        type="button"
+                      >
+                        Revoke
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+        <div
+          className="row mt-2"
+        >
+          <div
+            className="col d-flex justify-content-center"
+          >
+            <nav
+              aria-label="code-search-results-pagination"
+            >
+              <div
+                aria-atomic={true}
+                aria-live="polite"
+                aria-relevant="text"
+                className="sr-only"
+              >
+                Page 1, Current Page, of 1
+              </div>
+              <ul
+                className="pagination"
+              >
+                <li
+                  className="page-item disabled"
+                >
+                  <button
+                    aria-label="Previous"
+                    className="btn previous page-link"
+                    disabled={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    tabIndex="-1"
+                    type="button"
+                  >
+                    <div>
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-chevron-left mr-2"
+                        id="pagination-8"
+                      />
+                      Previous
+                    </div>
+                  </button>
+                </li>
+                <li
+                  className="page-item disabled"
+                >
+                  <button
+                    aria-label="Next"
+                    className="btn next page-link"
+                    disabled={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    tabIndex="-1"
+                    type="button"
+                  >
+                    <div>
+                      Next
+                      <span
+                        aria-hidden={true}
+                        className="fa fa-chevron-right ml-2"
+                        id="pagination-9"
+                      />
+                    </div>
+                  </button>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/CodeSearchResults/index.jsx
+++ b/src/components/CodeSearchResults/index.jsx
@@ -49,6 +49,7 @@ class CodeSearchResults extends React.Component {
     this.state = {
       isCodeReminderSuccessful: false,
       isCodeRevokeSuccessful: false,
+      shouldRefreshTable: false,
     };
   }
 
@@ -56,6 +57,7 @@ class CodeSearchResults extends React.Component {
     const { searchQuery, isOpen } = this.props;
     if (isOpen && searchQuery !== prevProps.searchQuery) {
       this.resetCodeActionMessages();
+      this.resetShouldRefreshTable();
     }
   }
 
@@ -63,6 +65,12 @@ class CodeSearchResults extends React.Component {
     this.setState({
       isCodeReminderSuccessful: false,
       isCodeRevokeSuccessful: false,
+    });
+  };
+
+  resetShouldRefreshTable = () => {
+    this.setState({
+      shouldRefreshTable: false,
     });
   };
 
@@ -173,6 +181,7 @@ class CodeSearchResults extends React.Component {
   handleRevokeOnSuccess = () => {
     this.setState({
       isCodeRevokeSuccessful: true,
+      shouldRefreshTable: true,
     });
   };
 
@@ -205,9 +214,10 @@ class CodeSearchResults extends React.Component {
 
   renderTable = () => {
     const { searchQuery } = this.props;
+    const { shouldRefreshTable } = this.state;
     return (
       <TableContainer
-        key={`code-search-results-${searchQuery}`}
+        key={`code-search-results-${searchQuery}-${shouldRefreshTable}`}
         id="code-search-results"
         className="code-search-results-table"
         fetchMethod={() => EcommerceApiService.fetchCodeSearchResults({

--- a/src/components/CodeSearchResults/index.jsx
+++ b/src/components/CodeSearchResults/index.jsx
@@ -184,13 +184,13 @@ class CodeSearchResults extends React.Component {
   renderHeading = () => {
     const { searchQuery, onClose } = this.props;
     return (
-      <div className="row mb-3">
-        <div className="col-12 col-md-8">
-          <h3 className="lead m-0 mb-2 mb-md-0">
+      <div className="d-flex align-items-center justify-content-between mb-3">
+        <div className="flex-grow-1 text-truncate mr-3">
+          <h3 className="lead m-0 text-truncate">
             Search results for <em>&quot;{searchQuery}&quot;</em>
           </h3>
         </div>
-        <div className="col text-md-right">
+        <div className="flex-grow-0 flex-shrink-0">
           <Button
             className="close-search-results-btn btn-outline-primary"
             onClick={onClose}

--- a/src/components/CodeSearchResults/index.jsx
+++ b/src/components/CodeSearchResults/index.jsx
@@ -1,51 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
-import {
-  Button,
-  Icon,
-  TransitionReplace,
-} from '@edx/paragon';
+import { TransitionReplace } from '@edx/paragon';
 
-import EcommerceApiService from '../../data/services/EcommerceApiService';
 import { isValidEmail } from '../../utils';
 
-import TableContainer from '../../containers/TableContainer';
 import StatusAlert from '../StatusAlert';
-import RemindButton from '../RemindButton';
-import RevokeButton from '../RevokeButton';
+import CodeSearchResultsHeading from './CodeSearchResultsHeading';
+import CodeSearchResultsTable from './CodeSearchResultsTable';
 
 import './CodeSearchResults.scss';
 
 class CodeSearchResults extends React.Component {
   constructor(props) {
     super(props);
-    this.tableColumns = [
-      {
-        label: 'Coupon Batch',
-        key: 'couponName',
-      },
-      {
-        label: 'Code',
-        key: 'code',
-      },
-      {
-        label: 'Redeemed',
-        key: 'isRedeemed',
-      },
-      {
-        label: 'Redemption Date',
-        key: 'redemptionDate',
-      },
-      {
-        label: 'Course Title',
-        key: 'courseTitle',
-      },
-      {
-        label: 'Actions',
-        key: 'actions',
-      },
-    ];
     this.state = {
       isCodeReminderSuccessful: false,
       isCodeRevokeSuccessful: false,
@@ -74,104 +41,6 @@ class CodeSearchResults extends React.Component {
     });
   };
 
-  /**
-   * The search API response contains a record for each coupon batch a
-   * user is associated with (i.e., has unused assignments, or actual
-   * redemptions). Under each coupon batch is an array of assignments and
-   * redemptiions, that contains all the metadata associated with a redemption,
-   * if applicable. Because we want the search results UI to show a row
-   * for each unused assignment and all redeemed courses associated with a
-   * particular user, this function flattens the search results by creating
-   * a new table row for each value in `redemptions_and_assignments`.
-   */
-  transformSearchResults = (items) => {
-    const itemsSortedByCouponId = items.sort((itemA, itemB) => itemA.coupon_id - itemB.coupon_id);
-    const flat = [];
-    itemsSortedByCouponId.forEach((item) => {
-      const {
-        redemptions_and_assignments: redemptionsAssignments,
-        coupon_id: couponId,
-        coupon_name: couponName,
-      } = item;
-      const isRedemptionsAssignmentsArray = Array.isArray(redemptionsAssignments);
-      const hasRedemptionsAssignments = (
-        isRedemptionsAssignmentsArray && redemptionsAssignments.length > 0
-      );
-      const data = {
-        couponId,
-        couponName,
-      };
-      if (hasRedemptionsAssignments) {
-        redemptionsAssignments.forEach(({
-          course_title: courseTitle,
-          redeemed_date: redemptionDate,
-          code,
-        }) => {
-          const getFormattedDate = (date) => {
-            if (!date) {
-              return null;
-            }
-            return moment(date).format('MMMM D, YYYY');
-          };
-          flat.push({
-            ...data,
-            courseTitle,
-            redemptionDate: getFormattedDate(redemptionDate),
-            code,
-            isRedeemed: !!redemptionDate,
-          });
-        });
-      }
-    });
-    return flat;
-  };
-
-  formatSearchResultsData = (results) => {
-    const { searchQuery } = this.props;
-    const transformedSearchResults = this.transformSearchResults(results);
-    const defaultEmptyValue = '-';
-    return transformedSearchResults.map(({
-      isRedeemed,
-      couponId,
-      courseTitle,
-      redemptionDate,
-      code,
-      couponName,
-    }) => ({
-      couponId,
-      couponName,
-      code,
-      isRedeemed: isRedeemed ? (
-        <Icon className="fa fa-check text-primary" screenReaderText="has been redeemed" />
-      ) : defaultEmptyValue,
-      courseTitle: courseTitle || defaultEmptyValue,
-      redemptionDate: redemptionDate || defaultEmptyValue,
-      actions: !isRedeemed ? (
-        <React.Fragment>
-          <RemindButton
-            couponId={couponId}
-            couponTitle={couponName}
-            data={{
-              email: searchQuery,
-              code,
-            }}
-            onSuccess={this.handleRemindOnSuccess}
-          />
-          {' | '}
-          <RevokeButton
-            couponId={couponId}
-            couponTitle={couponName}
-            data={{
-              assigned_to: searchQuery,
-              code,
-            }}
-            onSuccess={this.handleRevokeOnSuccess}
-          />
-        </React.Fragment>
-      ) : defaultEmptyValue,
-    }));
-  };
-
   handleRemindOnSuccess = () => {
     this.setState({
       isCodeReminderSuccessful: true,
@@ -188,45 +57,6 @@ class CodeSearchResults extends React.Component {
   isValidSearchQuery = () => {
     const { searchQuery } = this.props;
     return isValidEmail(searchQuery) === undefined;
-  };
-
-  renderHeading = () => {
-    const { searchQuery, onClose } = this.props;
-    return (
-      <div className="d-flex align-items-center justify-content-between mb-3">
-        <div className="flex-grow-1 text-truncate mr-3">
-          <h3 className="lead m-0 text-truncate">
-            Search results for <em>&quot;{searchQuery}&quot;</em>
-          </h3>
-        </div>
-        <div className="flex-grow-0 flex-shrink-0">
-          <Button
-            className="close-search-results-btn btn-outline-primary"
-            onClick={onClose}
-          >
-            <Icon className="fa fa-times mr-2" />
-              Close search results
-          </Button>
-        </div>
-      </div>
-    );
-  };
-
-  renderTable = () => {
-    const { searchQuery } = this.props;
-    const { shouldRefreshTable } = this.state;
-    return (
-      <TableContainer
-        key={`code-search-results-${searchQuery}-${shouldRefreshTable}`}
-        id="code-search-results"
-        className="code-search-results-table"
-        fetchMethod={() => EcommerceApiService.fetchCodeSearchResults({
-          user_email: searchQuery,
-        })}
-        columns={this.tableColumns}
-        formatData={this.formatSearchResultsData}
-      />
-    );
   };
 
   renderSuccessMessage = options => (
@@ -248,15 +78,22 @@ class CodeSearchResults extends React.Component {
   );
 
   render() {
-    const { isOpen, searchQuery } = this.props;
-    const { isCodeReminderSuccessful, isCodeRevokeSuccessful } = this.state;
+    const { isOpen, searchQuery, onClose } = this.props;
+    const {
+      isCodeReminderSuccessful,
+      isCodeRevokeSuccessful,
+      shouldRefreshTable,
+    } = this.state;
     const isValidSearchQuery = this.isValidSearchQuery();
     return (
       <TransitionReplace>
         {isOpen ? (
           <div key="code-search-results" className="code-search-results border-bottom pb-4">
             <React.Fragment>
-              {this.renderHeading()}
+              <CodeSearchResultsHeading
+                searchQuery={searchQuery}
+                onClose={onClose}
+              />
               {isValidSearchQuery ? (
                 <React.Fragment>
                   {isCodeReminderSuccessful && this.renderSuccessMessage({
@@ -265,7 +102,12 @@ class CodeSearchResults extends React.Component {
                   {isCodeRevokeSuccessful && this.renderSuccessMessage({
                     message: 'Successfully revoked code(s)',
                   })}
-                  {this.renderTable()}
+                  <CodeSearchResultsTable
+                    searchQuery={searchQuery}
+                    shouldRefreshTable={shouldRefreshTable}
+                    onRemindSuccess={this.handleRemindOnSuccess}
+                    onRevokeSuccess={this.handleRevokeOnSuccess}
+                  />
                 </React.Fragment>
               ) : (
                 <React.Fragment>

--- a/src/components/CodeSearchResults/index.jsx
+++ b/src/components/CodeSearchResults/index.jsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import {
+  Button,
+  Icon,
+  TransitionReplace,
+} from '@edx/paragon';
+
+import EcommerceApiService from '../../data/services/EcommerceApiService';
+import { isValidEmail } from '../../utils';
+
+import TableContainer from '../../containers/TableContainer';
+import StatusAlert from '../StatusAlert';
+import RemindButton from '../RemindButton';
+import RevokeButton from '../RevokeButton';
+
+import './CodeSearchResults.scss';
+
+class CodeSearchResults extends React.Component {
+  constructor(props) {
+    super(props);
+    this.tableColumns = [
+      {
+        label: 'Coupon Batch',
+        key: 'couponName',
+      },
+      {
+        label: 'Code',
+        key: 'code',
+      },
+      {
+        label: 'Redeemed',
+        key: 'isRedeemed',
+      },
+      {
+        label: 'Redemption Date',
+        key: 'redemptionDate',
+      },
+      {
+        label: 'Course Title',
+        key: 'courseTitle',
+      },
+      {
+        label: 'Actions',
+        key: 'actions',
+      },
+    ];
+    this.state = {
+      isCodeReminderSuccessful: false,
+      isCodeRevokeSuccessful: false,
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const { searchQuery, isOpen } = this.props;
+    if (isOpen && searchQuery !== prevProps.searchQuery) {
+      this.resetCodeActionMessages();
+    }
+  }
+
+  resetCodeActionMessages = () => {
+    this.setState({
+      isCodeReminderSuccessful: false,
+      isCodeRevokeSuccessful: false,
+    });
+  };
+
+  /**
+   * The search API response contains a record for each coupon batch a
+   * user is associated with (i.e., has unused assignments, or actual
+   * redemptions). Under each coupon batch is an array of assignments and
+   * redemptiions, that contains all the metadata associated with a redemption,
+   * if applicable. Because we want the search results UI to show a row
+   * for each unused assignment and all redeemed courses associated with a
+   * particular user, this function flattens the search results by creating
+   * a new table row for each value in `redemptions_and_assignments`.
+   */
+  transformSearchResults = (items) => {
+    const itemsSortedByCouponId = items.sort((itemA, itemB) => itemA.coupon_id - itemB.coupon_id);
+    const flat = [];
+    itemsSortedByCouponId.forEach((item) => {
+      const {
+        redemptions_and_assignments: redemptionsAssignments,
+        coupon_id: couponId,
+        coupon_name: couponName,
+      } = item;
+      const isRedemptionsAssignmentsArray = Array.isArray(redemptionsAssignments);
+      const hasRedemptionsAssignments = (
+        isRedemptionsAssignmentsArray && redemptionsAssignments.length > 0
+      );
+      const data = {
+        couponId,
+        couponName,
+      };
+      if (hasRedemptionsAssignments) {
+        redemptionsAssignments.forEach(({
+          course_title: courseTitle,
+          redeemed_date: redemptionDate,
+          code,
+        }) => {
+          const getFormattedDate = (date) => {
+            if (!date) {
+              return null;
+            }
+            return moment(date).format('MMMM D, YYYY');
+          };
+          flat.push({
+            ...data,
+            courseTitle,
+            redemptionDate: getFormattedDate(redemptionDate),
+            code,
+            isRedeemed: !!redemptionDate,
+          });
+        });
+      }
+    });
+    return flat;
+  };
+
+  formatSearchResultsData = (results) => {
+    const { searchQuery } = this.props;
+    const transformedSearchResults = this.transformSearchResults(results);
+    const defaultEmptyValue = '-';
+    return transformedSearchResults.map(({
+      isRedeemed,
+      couponId,
+      courseTitle,
+      redemptionDate,
+      code,
+      couponName,
+    }) => ({
+      couponId,
+      couponName,
+      code,
+      isRedeemed: isRedeemed ? (
+        <Icon className="fa fa-check text-primary" screenReaderText="has been redeemed" />
+      ) : defaultEmptyValue,
+      courseTitle: courseTitle || defaultEmptyValue,
+      redemptionDate: redemptionDate || defaultEmptyValue,
+      actions: !isRedeemed ? (
+        <React.Fragment>
+          <RemindButton
+            couponId={couponId}
+            couponTitle={couponName}
+            data={{
+              email: searchQuery,
+              code,
+            }}
+            onSuccess={this.handleRemindOnSuccess}
+          />
+          {' | '}
+          <RevokeButton
+            couponId={couponId}
+            couponTitle={couponName}
+            data={{
+              assigned_to: searchQuery,
+              code,
+            }}
+            onSuccess={this.handleRevokeOnSuccess}
+          />
+        </React.Fragment>
+      ) : defaultEmptyValue,
+    }));
+  };
+
+  handleRemindOnSuccess = () => {
+    this.setState({
+      isCodeReminderSuccessful: true,
+    });
+  };
+
+  handleRevokeOnSuccess = () => {
+    this.setState({
+      isCodeRevokeSuccessful: true,
+    });
+  };
+
+  isValidSearchQuery = () => {
+    const { searchQuery } = this.props;
+    return isValidEmail(searchQuery) === undefined;
+  };
+
+  renderHeading = () => {
+    const { searchQuery, onClose } = this.props;
+    return (
+      <div className="row mb-3">
+        <div className="col-12 col-md-8">
+          <h3 className="lead m-0 mb-2 mb-md-0">
+            Search results for <em>&quot;{searchQuery}&quot;</em>
+          </h3>
+        </div>
+        <div className="col text-md-right">
+          <Button
+            className="close-search-results-btn btn-outline-primary"
+            onClick={onClose}
+          >
+            <Icon className="fa fa-times mr-2" />
+              Close search results
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  renderTable = () => {
+    const { searchQuery } = this.props;
+    return (
+      <TableContainer
+        key={`code-search-results-${searchQuery}`}
+        id="code-search-results"
+        className="code-search-results-table"
+        fetchMethod={() => EcommerceApiService.fetchCodeSearchResults({
+          user_email: searchQuery,
+        })}
+        columns={this.tableColumns}
+        formatData={this.formatSearchResultsData}
+      />
+    );
+  };
+
+  renderSuccessMessage = options => (
+    <StatusAlert
+      alertType="success"
+      iconClassName="fa fa-check"
+      onClose={this.resetCodeActionMessages}
+      dismissible
+      {...options}
+    />
+  );
+
+  renderErrorMessage = options => (
+    <StatusAlert
+      alertType="danger"
+      iconClassName="fa fa-exclamation-circle"
+      {...options}
+    />
+  );
+
+  render() {
+    const { isOpen, searchQuery } = this.props;
+    const { isCodeReminderSuccessful, isCodeRevokeSuccessful } = this.state;
+    const isValidSearchQuery = this.isValidSearchQuery();
+    return (
+      <TransitionReplace>
+        {isOpen ? (
+          <div key="code-search-results" className="code-search-results border-bottom pb-4">
+            <React.Fragment>
+              {this.renderHeading()}
+              {isValidSearchQuery ? (
+                <React.Fragment>
+                  {isCodeReminderSuccessful && this.renderSuccessMessage({
+                    message: `A reminder was successfully sent to ${searchQuery}.`,
+                  })}
+                  {isCodeRevokeSuccessful && this.renderSuccessMessage({
+                    message: 'Successfully revoked code(s)',
+                  })}
+                  {this.renderTable()}
+                </React.Fragment>
+              ) : (
+                <React.Fragment>
+                  {this.renderErrorMessage({
+                    message: 'Please enter a valid email address in your search.',
+                  })}
+                </React.Fragment>
+              )}
+            </React.Fragment>
+          </div>
+        ) : null}
+      </TransitionReplace>
+    );
+  }
+}
+
+CodeSearchResults.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool,
+  searchQuery: PropTypes.string,
+};
+
+CodeSearchResults.defaultProps = {
+  isOpen: false,
+  searchQuery: null,
+};
+
+export default CodeSearchResults;

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -15,6 +15,8 @@ import { SINGLE_USE, ONCE_PER_CUSTOMER } from '../../data/constants/coupons';
 import EcommerceApiService from '../../data/services/EcommerceApiService';
 
 import './CouponDetails.scss';
+import RemindButton from '../RemindButton';
+import RevokeButton from '../RevokeButton';
 
 class CouponDetails extends React.Component {
   constructor(props) {
@@ -65,8 +67,6 @@ class CouponDetails extends React.Component {
       ],
       modals: {
         assignment: null,
-        revoke: null,
-        remind: null,
       },
       isCodeAssignmentSuccessful: undefined,
       isCodeReminderSuccessful: undefined,
@@ -191,41 +191,27 @@ class CouponDetails extends React.Component {
         <React.Fragment>
           {!codeHasError && (
             <React.Fragment>
-              <Button
-                className={`remind-btn ${buttonClassNames.join(' ')}`}
-                onClick={() => this.setModalState({
-                  key: 'remind',
-                  options: {
-                    couponId: id,
-                    title: couponTitle,
-                    data: {
-                      code: code.code,
-                      email: code.assigned_to,
-                    },
-                  },
-                })}
-              >
-                Remind
-              </Button>
-              <span>|</span>
+              <RemindButton
+                couponId={id}
+                couponTitle={couponTitle}
+                data={{
+                  code: code.code,
+                  email: code.assigned_to,
+                }}
+                onSuccess={response => this.handleCodeActionSuccess('remind', response)}
+              />
+              {' | '}
             </React.Fragment>
           )}
-          <Button
-            className={`revoke-btn ${buttonClassNames.join(' ')}`}
-            onClick={() => this.setModalState({
-              key: 'revoke',
-              options: {
-                couponId: id,
-                title: couponTitle,
-                data: {
-                  code: code.code,
-                  assigned_to: code.assigned_to,
-                },
-              },
-            })}
-          >
-            Revoke
-          </Button>
+          <RevokeButton
+            couponId={id}
+            couponTitle={couponTitle}
+            data={{
+              assigned_to: code.assigned_to,
+              code: code.code,
+            }}
+            onSuccess={response => this.handleCodeActionSuccess('revoke', response)}
+          />
         </React.Fragment>
       );
     }

--- a/src/components/RemindButton/index.jsx
+++ b/src/components/RemindButton/index.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@edx/paragon';
+
+import CodeReminderModal from '../../containers/CodeReminderModal';
+
+class RemindButton extends React.Component {
+  state = {
+    isModalOpen: false,
+  };
+
+  handleRemindButtonClick = () => {
+    this.setState({ isModalOpen: true });
+  };
+
+  handleOnSuccess = (response) => {
+    const { onSuccess } = this.props;
+    onSuccess(response);
+  }
+
+  handleOnClose = () => {
+    const { onClose } = this.props;
+    this.setState({ isModalOpen: false });
+    if (onClose) {
+      onClose();
+    }
+  }
+
+  render() {
+    const { couponId, couponTitle, data } = this.props;
+    const { isModalOpen } = this.state;
+    return (
+      <React.Fragment>
+        <Button
+          className="remind-btn btn-link btn-sm p-0"
+          onClick={this.handleRemindButtonClick}
+        >
+          Remind
+        </Button>
+        {isModalOpen && (
+          <CodeReminderModal
+            couponId={couponId}
+            title={couponTitle}
+            data={data}
+            onSuccess={this.handleOnSuccess}
+            onClose={this.handleOnClose}
+          />
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+RemindButton.propTypes = {
+  couponId: PropTypes.number.isRequired,
+  couponTitle: PropTypes.string.isRequired,
+  data: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    email: PropTypes.string.isRequired,
+  }).isRequired,
+  onSuccess: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
+};
+
+RemindButton.defaultProps = {
+  onClose: null,
+};
+
+export default RemindButton;

--- a/src/components/RemindButton/index.jsx
+++ b/src/components/RemindButton/index.jsx
@@ -1,55 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
 
 import CodeReminderModal from '../../containers/CodeReminderModal';
+import ActionButtonWithModal from '../ActionButtonWithModal';
 
-class RemindButton extends React.Component {
-  state = {
-    isModalOpen: false,
-  };
-
-  handleRemindButtonClick = () => {
-    this.setState({ isModalOpen: true });
-  };
-
-  handleOnSuccess = (response) => {
-    const { onSuccess } = this.props;
-    onSuccess(response);
-  }
-
-  handleOnClose = () => {
-    const { onClose } = this.props;
-    this.setState({ isModalOpen: false });
-    if (onClose) {
-      onClose();
-    }
-  }
-
-  render() {
-    const { couponId, couponTitle, data } = this.props;
-    const { isModalOpen } = this.state;
-    return (
-      <React.Fragment>
-        <Button
-          className="remind-btn btn-link btn-sm p-0"
-          onClick={this.handleRemindButtonClick}
-        >
-          Remind
-        </Button>
-        {isModalOpen && (
-          <CodeReminderModal
-            couponId={couponId}
-            title={couponTitle}
-            data={data}
-            onSuccess={this.handleOnSuccess}
-            onClose={this.handleOnClose}
-          />
-        )}
-      </React.Fragment>
-    );
-  }
-}
+const RemindButton = ({
+  couponId,
+  couponTitle,
+  data,
+  onSuccess,
+  onClose,
+}) => (
+  <ActionButtonWithModal
+    buttonLabel="Remind"
+    buttonClassName="remind-btn"
+    renderModal={({ closeModal }) => (
+      <CodeReminderModal
+        couponId={couponId}
+        title={couponTitle}
+        data={data}
+        onSuccess={onSuccess}
+        onClose={() => {
+          closeModal();
+          if (onClose) {
+            onClose();
+          }
+        }}
+      />
+    )}
+  />
+);
 
 RemindButton.propTypes = {
   couponId: PropTypes.number.isRequired,

--- a/src/components/RevokeButton/index.jsx
+++ b/src/components/RevokeButton/index.jsx
@@ -1,55 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
 
 import CodeRevokeModal from '../../containers/CodeRevokeModal';
+import ActionButtonWithModal from '../ActionButtonWithModal';
 
-class RevokeButton extends React.Component {
-  state = {
-    isModalOpen: false,
-  };
-
-  handleRevokeButtonClick = () => {
-    this.setState({ isModalOpen: true });
-  };
-
-  handleOnSuccess = (response) => {
-    const { onSuccess } = this.props;
-    onSuccess(response);
-  }
-
-  handleOnClose = () => {
-    const { onClose } = this.props;
-    this.setState({ isModalOpen: false });
-    if (onClose) {
-      onClose();
-    }
-  }
-
-  render() {
-    const { couponId, couponTitle, data } = this.props;
-    const { isModalOpen } = this.state;
-    return (
-      <React.Fragment>
-        <Button
-          className="revoke-btn btn-link btn-sm p-0"
-          onClick={this.handleRevokeButtonClick}
-        >
-          Revoke
-        </Button>
-        {isModalOpen && (
-          <CodeRevokeModal
-            couponId={couponId}
-            title={couponTitle}
-            data={data}
-            onSuccess={this.handleOnSuccess}
-            onClose={this.handleOnClose}
-          />
-        )}
-      </React.Fragment>
-    );
-  }
-}
+const RevokeButton = ({
+  couponId,
+  couponTitle,
+  data,
+  onSuccess,
+  onClose,
+}) => (
+  <ActionButtonWithModal
+    buttonLabel="Revoke"
+    buttonClassName="revoke-btn"
+    renderModal={({ closeModal }) => (
+      <CodeRevokeModal
+        couponId={couponId}
+        title={couponTitle}
+        data={data}
+        onSuccess={onSuccess}
+        onClose={() => {
+          closeModal();
+          if (onClose) {
+            onClose();
+          }
+        }}
+      />
+    )}
+  />
+);
 
 RevokeButton.propTypes = {
   couponId: PropTypes.number.isRequired,

--- a/src/components/RevokeButton/index.jsx
+++ b/src/components/RevokeButton/index.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@edx/paragon';
+
+import CodeRevokeModal from '../../containers/CodeRevokeModal';
+
+class RevokeButton extends React.Component {
+  state = {
+    isModalOpen: false,
+  };
+
+  handleRevokeButtonClick = () => {
+    this.setState({ isModalOpen: true });
+  };
+
+  handleOnSuccess = (response) => {
+    const { onSuccess } = this.props;
+    onSuccess(response);
+  }
+
+  handleOnClose = () => {
+    const { onClose } = this.props;
+    this.setState({ isModalOpen: false });
+    if (onClose) {
+      onClose();
+    }
+  }
+
+  render() {
+    const { couponId, couponTitle, data } = this.props;
+    const { isModalOpen } = this.state;
+    return (
+      <React.Fragment>
+        <Button
+          className="revoke-btn btn-link btn-sm p-0"
+          onClick={this.handleRevokeButtonClick}
+        >
+          Revoke
+        </Button>
+        {isModalOpen && (
+          <CodeRevokeModal
+            couponId={couponId}
+            title={couponTitle}
+            data={data}
+            onSuccess={this.handleOnSuccess}
+            onClose={this.handleOnClose}
+          />
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+RevokeButton.propTypes = {
+  couponId: PropTypes.number.isRequired,
+  couponTitle: PropTypes.string.isRequired,
+  data: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    assigned_to: PropTypes.string.isRequired,
+  }).isRequired,
+  onSuccess: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
+};
+
+RevokeButton.defaultProps = {
+  onClose: null,
+};
+
+export default RevokeButton;

--- a/src/containers/CodeManagementPage/__snapshots__/CodeManagementPage.test.jsx.snap
+++ b/src/containers/CodeManagementPage/__snapshots__/CodeManagementPage.test.jsx.snap
@@ -35,10 +35,10 @@ Array [
     className="container-fluid"
   >
     <div
-      className="row mt-4 mb-3"
+      className="row mt-4 mb-3 no-gutters"
     >
       <div
-        className="col-12 col-md-3 mb-2 mb-md-0"
+        className="col-12 col-xl-3 mb-3 mb-xl-0"
       >
         <h2
           className={null}
@@ -47,7 +47,79 @@ Array [
         </h2>
       </div>
       <div
-        className="col-12 col-md-9 mb-2 mb-md-0 text-md-right"
+        className="col-12 col-xl-4 mb-3 mb-xl-0 offset-xl-1"
+      >
+        <div
+          className="border search-field"
+          onBlur={[Function]}
+          onFocus={[Function]}
+        >
+          <div
+            className="form-group form-inline"
+          >
+            <label
+              className=""
+              htmlFor="asInput2"
+              id="label-asInput2"
+            >
+              Search by email:
+            </label>
+            <div
+              className="input-group"
+            >
+              <div
+                className="input-group-prepend"
+              />
+              <input
+                aria-describedby="error-asInput2"
+                aria-invalid={false}
+                autoComplete="off"
+                className="form-control is-invalid-nodanger input no-clear-btn"
+                disabled={false}
+                id="asInput2"
+                name="search"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyPress={[Function]}
+                placeholder=""
+                required={false}
+                role="searchbox"
+                type="search"
+                value=""
+              />
+              <div
+                className="input-group-append"
+              >
+                <button
+                  className="search-btn"
+                  disabled={true}
+                  onClick={[Function]}
+                >
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon3"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-live="polite"
+              className="invalid-feedback invalid-feedback-nodanger"
+              id="error-asInput2"
+            >
+              <span />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-12 col-xl-4 mb-3 mb-xl-0 text-xl-right"
       >
         <button
           className="btn mr-2 btn-link"
@@ -60,7 +132,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-refresh mr-2"
-            id="Icon2"
+            id="Icon4"
           />
           Refresh data
         </button>
@@ -72,10 +144,26 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-plus mr-2"
-            id="Icon3"
+            id="Icon5"
           />
           Request more codes
         </a>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <div
+          className="pgn-transition-replace-group position-relative"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        />
       </div>
     </div>
     <div
@@ -101,7 +189,7 @@ Array [
                 <span
                   aria-hidden={true}
                   className="fa fa-exclamation-circle"
-                  id="Icon4"
+                  id="Icon6"
                 />
               </div>
               <div
@@ -153,10 +241,10 @@ Array [
     className="container-fluid"
   >
     <div
-      className="row mt-4 mb-3"
+      className="row mt-4 mb-3 no-gutters"
     >
       <div
-        className="col-12 col-md-3 mb-2 mb-md-0"
+        className="col-12 col-xl-3 mb-3 mb-xl-0"
       >
         <h2
           className={null}
@@ -165,7 +253,79 @@ Array [
         </h2>
       </div>
       <div
-        className="col-12 col-md-9 mb-2 mb-md-0 text-md-right"
+        className="col-12 col-xl-4 mb-3 mb-xl-0 offset-xl-1"
+      >
+        <div
+          className="border search-field"
+          onBlur={[Function]}
+          onFocus={[Function]}
+        >
+          <div
+            className="form-group form-inline"
+          >
+            <label
+              className=""
+              htmlFor="asInput19"
+              id="label-asInput19"
+            >
+              Search by email:
+            </label>
+            <div
+              className="input-group"
+            >
+              <div
+                className="input-group-prepend"
+              />
+              <input
+                aria-describedby="error-asInput19"
+                aria-invalid={false}
+                autoComplete="off"
+                className="form-control is-invalid-nodanger input no-clear-btn"
+                disabled={false}
+                id="asInput19"
+                name="search"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyPress={[Function]}
+                placeholder=""
+                required={false}
+                role="searchbox"
+                type="search"
+                value=""
+              />
+              <div
+                className="input-group-append"
+              >
+                <button
+                  className="search-btn"
+                  disabled={true}
+                  onClick={[Function]}
+                >
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon20"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-live="polite"
+              className="invalid-feedback invalid-feedback-nodanger"
+              id="error-asInput19"
+            >
+              <span />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-12 col-xl-4 mb-3 mb-xl-0 text-xl-right"
       >
         <button
           className="btn mr-2 btn-link"
@@ -178,7 +338,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-refresh mr-2"
-            id="Icon13"
+            id="Icon21"
           />
           Refresh data
         </button>
@@ -190,10 +350,26 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-plus mr-2"
-            id="Icon14"
+            id="Icon22"
           />
           Request more codes
         </a>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <div
+          className="pgn-transition-replace-group position-relative"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        />
       </div>
     </div>
     <div
@@ -219,7 +395,7 @@ Array [
                 <span
                   aria-hidden={true}
                   className="fa fa-times-circle"
-                  id="Icon15"
+                  id="Icon23"
                 />
               </div>
               <div
@@ -276,10 +452,10 @@ Array [
     className="container-fluid"
   >
     <div
-      className="row mt-4 mb-3"
+      className="row mt-4 mb-3 no-gutters"
     >
       <div
-        className="col-12 col-md-3 mb-2 mb-md-0"
+        className="col-12 col-xl-3 mb-3 mb-xl-0"
       >
         <h2
           className={null}
@@ -288,7 +464,79 @@ Array [
         </h2>
       </div>
       <div
-        className="col-12 col-md-9 mb-2 mb-md-0 text-md-right"
+        className="col-12 col-xl-4 mb-3 mb-xl-0 offset-xl-1"
+      >
+        <div
+          className="border search-field"
+          onBlur={[Function]}
+          onFocus={[Function]}
+        >
+          <div
+            className="form-group form-inline"
+          >
+            <label
+              className=""
+              htmlFor="asInput15"
+              id="label-asInput15"
+            >
+              Search by email:
+            </label>
+            <div
+              className="input-group"
+            >
+              <div
+                className="input-group-prepend"
+              />
+              <input
+                aria-describedby="error-asInput15"
+                aria-invalid={false}
+                autoComplete="off"
+                className="form-control is-invalid-nodanger input no-clear-btn"
+                disabled={false}
+                id="asInput15"
+                name="search"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyPress={[Function]}
+                placeholder=""
+                required={false}
+                role="searchbox"
+                type="search"
+                value=""
+              />
+              <div
+                className="input-group-append"
+              >
+                <button
+                  className="search-btn"
+                  disabled={true}
+                  onClick={[Function]}
+                >
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon16"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-live="polite"
+              className="invalid-feedback invalid-feedback-nodanger"
+              id="error-asInput15"
+            >
+              <span />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-12 col-xl-4 mb-3 mb-xl-0 text-xl-right"
       >
         <button
           className="btn mr-2 btn-link"
@@ -301,7 +549,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-refresh mr-2"
-            id="Icon11"
+            id="Icon17"
           />
           Refresh data
         </button>
@@ -313,10 +561,26 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-plus mr-2"
-            id="Icon12"
+            id="Icon18"
           />
           Request more codes
         </a>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <div
+          className="pgn-transition-replace-group position-relative"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        />
       </div>
     </div>
     <div
@@ -371,10 +635,10 @@ Array [
     className="container-fluid"
   >
     <div
-      className="row mt-4 mb-3"
+      className="row mt-4 mb-3 no-gutters"
     >
       <div
-        className="col-12 col-md-3 mb-2 mb-md-0"
+        className="col-12 col-xl-3 mb-3 mb-xl-0"
       >
         <h2
           className={null}
@@ -383,7 +647,79 @@ Array [
         </h2>
       </div>
       <div
-        className="col-12 col-md-9 mb-2 mb-md-0 text-md-right"
+        className="col-12 col-xl-4 mb-3 mb-xl-0 offset-xl-1"
+      >
+        <div
+          className="border search-field"
+          onBlur={[Function]}
+          onFocus={[Function]}
+        >
+          <div
+            className="form-group form-inline"
+          >
+            <label
+              className=""
+              htmlFor="asInput7"
+              id="label-asInput7"
+            >
+              Search by email:
+            </label>
+            <div
+              className="input-group"
+            >
+              <div
+                className="input-group-prepend"
+              />
+              <input
+                aria-describedby="error-asInput7"
+                aria-invalid={false}
+                autoComplete="off"
+                className="form-control is-invalid-nodanger input no-clear-btn"
+                disabled={false}
+                id="asInput7"
+                name="search"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyPress={[Function]}
+                placeholder=""
+                required={false}
+                role="searchbox"
+                type="search"
+                value=""
+              />
+              <div
+                className="input-group-append"
+              >
+                <button
+                  className="search-btn"
+                  disabled={true}
+                  onClick={[Function]}
+                >
+                  <span
+                    aria-hidden={true}
+                    className="fa fa-search"
+                    id="Icon8"
+                  />
+                  <span
+                    className="sr-only"
+                  >
+                    Submit search
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-live="polite"
+              className="invalid-feedback invalid-feedback-nodanger"
+              id="error-asInput7"
+            >
+              <span />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="col-12 col-xl-4 mb-3 mb-xl-0 text-xl-right"
       >
         <button
           className="btn mr-2 btn-link"
@@ -396,7 +732,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-refresh mr-2"
-            id="Icon5"
+            id="Icon9"
           />
           Refresh data
         </button>
@@ -408,10 +744,26 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-plus mr-2"
-            id="Icon6"
+            id="Icon10"
           />
           Request more codes
         </a>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <div
+          className="pgn-transition-replace-group position-relative"
+          style={
+            Object {
+              "height": null,
+            }
+          }
+        />
       </div>
     </div>
     <div
@@ -519,7 +871,7 @@ Array [
               <span
                 aria-hidden={true}
                 className="fa fa-chevron-down text-primary"
-                id="Icon7"
+                id="Icon11"
               />
               <span
                 className="sr-only"
@@ -636,7 +988,7 @@ Array [
               <span
                 aria-hidden={true}
                 className="fa fa-chevron-down text-primary"
-                id="Icon8"
+                id="Icon12"
               />
               <span
                 className="sr-only"
@@ -688,7 +1040,7 @@ Array [
                     <span
                       aria-hidden={true}
                       className="fa fa-chevron-left mr-2"
-                      id="pagination-9"
+                      id="pagination-13"
                     />
                     Previous
                   </div>
@@ -712,7 +1064,7 @@ Array [
                     <span
                       aria-hidden={true}
                       className="fa fa-chevron-right ml-2"
-                      id="pagination-10"
+                      id="pagination-14"
                     />
                   </div>
                 </button>

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -300,7 +300,12 @@ describe('CouponDetailsWrapper', () => {
       const actionButton = wrapper.find('table').find('button').find(`.${key}-btn`);
       expect(actionButton.prop('children')).toEqual(label);
       actionButton.simulate('click');
-      expect(wrapper.find('CouponDetails').instance().state.modals[key]).toBeTruthy();
+      // TODO: The remind/revoke buttons now manage their modal state in their
+      // own components, so we only need to worry about the `assign` action now.
+      // We might also want to move the Assign button to its own component as well.
+      if (key === 'assign') {
+        expect(wrapper.find('CouponDetails').instance().state.modals[key]).toBeTruthy();
+      }
     };
 
     beforeEach(() => {

--- a/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
+++ b/src/containers/CouponDetails/__snapshots__/CouponDetails.test.jsx.snap
@@ -848,9 +848,7 @@ exports[`CouponDetailsWrapper renders with table data 1`] = `
                     >
                       Remind
                     </button>
-                    <span>
-                      |
-                    </span>
+                     | 
                     <button
                       className="btn revoke-btn btn-link btn-sm p-0"
                       onBlur={[Function]}

--- a/src/data/services/EcommerceApiService.js
+++ b/src/data/services/EcommerceApiService.js
@@ -45,6 +45,15 @@ class EcommerceApiService {
     const url = `${EcommerceApiService.ecommerceBaseUrl}/api/v2/enterprise/coupons/${couponId}/revoke/`;
     return apiClient.post(url, options, 'json');
   }
+
+  static fetchCodeSearchResults(options) {
+    const { enterpriseId } = store.getState().portalConfiguration;
+    let url = `${EcommerceApiService.ecommerceBaseUrl}/api/v2/enterprise/coupons/${enterpriseId}/search/`;
+    if (options) {
+      url += `?${qs.stringify(options)}`;
+    }
+    return apiClient.get(url);
+  }
 }
 
 export default EcommerceApiService;

--- a/src/data/services/__mocks__/codeSearchResultsResponse.json
+++ b/src/data/services/__mocks__/codeSearchResultsResponse.json
@@ -1,0 +1,69 @@
+{
+  "data": {
+    "count": 3, 
+    "current_page": 1, 
+    "next": null, 
+    "num_pages": 1, 
+    "previous": null, 
+    "results": [
+      {
+        "coupon_id": 5, 
+        "coupon_name": "Test coupon 3", 
+        "id": 7, 
+        "redemptions_and_assignments": [
+          {
+            "code": "Y7XS3OGG7WB7KQ5R", 
+            "course_key": null, 
+            "course_title": null, 
+            "redeemed_date": null
+          },
+          {
+            "code": "Y7XS3OGG7WB7KQ5R",
+            "course_key": "course-v1:test-org+course+run",
+            "course_title": "course-name-EccHrARKjEsn",
+            "redeemed_date": "2019-08-29T19:13:23.851454Z"
+          }
+        ]
+      },
+      {
+        "coupon_id": 3, 
+        "coupon_name": "Test coupon", 
+        "id": 1, 
+        "redemptions_and_assignments": []
+      }, 
+      {
+        "coupon_id": 4, 
+        "coupon_name": "Test coupon 1", 
+        "id": 2, 
+        "redemptions_and_assignments": [
+          {
+            "code": "Y7XS3OGG7WB7KQ5R", 
+            "course_key": null, 
+            "course_title": null, 
+            "redeemed_date": null
+          }, 
+          {
+            "code": "Y7XS3OGG7WB7KQ5R", 
+            "course_key": "course-v1:test-org+course+run", 
+            "course_title": "course-name-EccHrARKjEsn", 
+            "redeemed_date": "2019-08-29T19:13:23.851454Z"
+          }
+        ]
+      }, 
+      {
+        "coupon_id": 5, 
+        "coupon_name": "Test coupon 3", 
+        "id": 7, 
+        "redemptions_and_assignments": [
+          {
+            "code": "ILSYLEH27WO36NMC", 
+            "course_key": "course-v1:test-org+course+run", 
+            "course_title": "course-name-EccHrARKjEsn", 
+            "redeemed_date": "2019-08-29T19:13:23.851454Z"
+          }
+        ]
+      }
+    ], 
+    "start": 0
+  }
+}


### PR DESCRIPTION
This PR adds the code search UI functionality as seen in the gif below:

![code_search](https://user-images.githubusercontent.com/2828721/63944234-2d1aeb00-ca3f-11e9-9a3d-626109684214.gif)

Note: I am currently working on getting the action buttons (remind/revoke) in the search results table, so that a user can take action on the relevant results right from the search results table. I am trying to reuse the same logic as those action buttons from the `CouponDetails` component and will be abstracting those action buttons and their associated logic into their own reusable component. Tests are still to come.

Supporting pagination will be some extra work as our `TableContainer` component does not currently support pagination when there is more than one table on the page, as is the case here when a coupon batch is expanded. We may want to punt on supporting pagination initially, and follow-up with a new ticket to support pagination in the `TableContainer` when there are multiple tables on the page.