### PR TITLE
fix: ENT-4745 | bugfix for csv upload for bulk assign modal

### DIFF
--- a/src/components/CodeAssignmentModal/index.jsx
+++ b/src/components/CodeAssignmentModal/index.jsx
@@ -298,7 +298,7 @@ export class BaseCodeAssignmentModal extends React.Component {
     }
 
     let pendingEnterpriseUserData;
-    if (hasTextAreaEmails) {
+    if (validEmails) {
       pendingEnterpriseUserData = validEmails.map((email) => ({
         user_email: email,
         enterprise_customer: enterpriseUuid,


### PR DESCRIPTION
# For all changes

the variable hasTextAreaEmails was used instead of validEmails. so if you used to CSV upload button, hasTextAreaEmails would be blank, resulting in the following code path from being hit
```
pendingEnterpriseUserData = {
        user_email: formData['email-address'],
        enterprise_customer: enterpriseUuid,
      };
```
but formData['email-address'] is nothing, and this would need to be a map anyway

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
