### PR TITLE
feat: Limit license search to associated subscription plan only

### DIFF
--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx
@@ -93,6 +93,7 @@ const BulkEnrollmentStepper = ({ subscription, enterpriseSlug, enterpriseId }) =
             <BulkEnrollmentSubmit
               enterpriseId={enterpriseId}
               enterpriseSlug={enterpriseSlug}
+              subscription={subscription}
               returnToInitialStep={() => setCurrentStep(ADD_COURSES_STEP)}
             />
           </Stepper.ActionRow>

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx
@@ -71,7 +71,9 @@ export const generateSuccessMessage = numEmails => {
   return 'No learners have been enrolled.';
 };
 
-const BulkEnrollmentSubmit = ({ enterpriseId, enterpriseSlug, returnToInitialStep }) => {
+const BulkEnrollmentSubmit = ({
+  enterpriseId, enterpriseSlug, subscription, returnToInitialStep,
+}) => {
   const [loading, setLoading] = useState(false);
   const [checked, setChecked] = useState(true);
   const [error, setError] = useState('');
@@ -100,6 +102,7 @@ const BulkEnrollmentSubmit = ({ enterpriseId, enterpriseSlug, returnToInitialSte
 
     return LicenseManagerApiService.licenseBulkEnroll(
       enterpriseId,
+      subscription.uuid,
       options,
     ).then(() => {
       coursesDispatch(clearSelectionAction());
@@ -144,6 +147,10 @@ const BulkEnrollmentSubmit = ({ enterpriseId, enterpriseSlug, returnToInitialSte
 BulkEnrollmentSubmit.propTypes = {
   enterpriseId: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
+  subscription: PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+    enterpriseCatalogUuid: PropTypes.string.isRequired,
+  }).isRequired,
   returnToInitialStep: PropTypes.func.isRequired,
 };
 

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
@@ -37,6 +37,7 @@ const testEntId = 'abc1234z-53c9-4071-b698-b8d436eb0295';
 const defaultProps = {
   enterpriseId: testEntId,
   enterpriseSlug: testSlug,
+  subscription: { uuid: 'foo', enterpriseCatalogUuid: 'bar' },
   returnToInitialStep: jest.fn(),
 };
 const defaultAlertProps = {
@@ -215,6 +216,7 @@ describe('BulkEnrollmentSubmit', () => {
 
     expect(LicenseManagerApiService.licenseBulkEnroll).toHaveBeenCalledWith(
       defaultProps.enterpriseId,
+      defaultProps.subscription.uuid,
       expectedParams,
     );
     expect(logError).toBeCalledTimes(0);
@@ -243,6 +245,7 @@ describe('BulkEnrollmentSubmit', () => {
     };
     expect(LicenseManagerApiService.licenseBulkEnroll).toHaveBeenCalledWith(
       defaultProps.enterpriseId,
+      defaultProps.subscription.uuid,
       expectedParams,
     );
     expect(logError).toBeCalledTimes(0);

--- a/src/data/actions/bulkEnrollment.js
+++ b/src/data/actions/bulkEnrollment.js
@@ -26,13 +26,14 @@ const sendBulkEnrollmentFailure = error => ({
 
 const sendBulkEnrollment = ({
   enterpriseUuid,
+  subscriptionUuid,
   options,
   onSuccess = () => {},
   onError = () => {},
 }) => (
   (dispatch) => {
     dispatch(sendBulkEnrollmentRequest());
-    return LicenseManagerAPIService.licenseBulkEnroll(enterpriseUuid, options)
+    return LicenseManagerAPIService.licenseBulkEnroll(enterpriseUuid, subscriptionUuid, options)
       .then((response) => {
         dispatch(sendBulkEnrollmentSuccess(response.data));
         onSuccess(response.data);

--- a/src/data/services/LicenseManagerAPIService.js
+++ b/src/data/services/LicenseManagerAPIService.js
@@ -148,8 +148,8 @@ class LicenseManagerApiService {
     return LicenseManagerApiService.apiClient().post(url);
   }
 
-  static licenseBulkEnroll(enterpriseUuid, options) {
-    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/bulk-license-enrollment/?enterprise_customer_uuid=${enterpriseUuid}`;
+  static licenseBulkEnroll(enterpriseUuid, subscriptionUUID, options) {
+    const url = `${LicenseManagerApiService.licenseManagerBaseUrl}/bulk-license-enrollment/?enterprise_customer_uuid=${enterpriseUuid}&subscription_uuid=${subscriptionUUID}`;
     return LicenseManagerApiService.apiClient().post(url, options);
   }
 


### PR DESCRIPTION
These are the frontend changes related to [ENT-4833](https://openedx.atlassian.net/browse/ENT-4833).

This changes the bulk enrollment step to pass the currently selected subscription uuid into the LicenseManagerApi bulk-enroll call. 

- [ENT-4833](https://openedx.atlassian.net/browse/ENT-4833)