### PR TITLE
fix: remove courses with expired VUD

### DIFF
--- a/src/components/BulkEnrollmentPage/stepper/AddCoursesStep.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/AddCoursesStep.jsx
@@ -9,6 +9,8 @@ import { ADD_COURSES_TITLE, ADD_COURSE_DESCRIPTION } from './constants';
 
 import CourseSearchResults from '../CourseSearchResults';
 
+const currentEpoch = Math.round((new Date()).getTime() / 1000);
+
 const searchClient = algoliasearch(
   configuration.ALGOLIA.APP_ID,
   configuration.ALGOLIA.SEARCH_API_KEY,
@@ -26,7 +28,7 @@ const AddCoursesStep = ({
         searchClient={searchClient}
       >
         <Configure
-          filters={`enterprise_catalog_uuids:${subscription.enterpriseCatalogUuid}`}
+          filters={`enterprise_catalog_uuids:${subscription.enterpriseCatalogUuid} AND advertised_course_run.upgrade_deadline>${currentEpoch}`}
           hitsPerPage={25}
         />
         <SearchHeader variant="default" />


### PR DESCRIPTION
Transforms algolia query to filter out courses in the bulk enrollment tool where the Verified Upgrade Deadline (VUD) has passed to avoid errors upon enrollment. 

Ticket https://openedx.atlassian.net/browse/ENT-4986

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
