### PR TITLE
fix: plan expiration CTA label now says 'Contact support'

### DIFF
--- a/src/components/ContactCustomerSupportButton/index.jsx
+++ b/src/components/ContactCustomerSupportButton/index.jsx
@@ -22,7 +22,7 @@ ContactCustomerSupportButton.propTypes = {
 };
 
 ContactCustomerSupportButton.defaultProps = {
-  children: 'Contact customer support',
+  children: 'Contact support',
   variant: 'outline-primary',
 };
 

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationBanner.test.jsx
@@ -114,7 +114,7 @@ describe('<SubscriptionExpirationBanner />', () => {
     }
   });
 
-  test('handles customer support button click', () => {
+  test('handles support button click', () => {
     const agreementNetDaysUntilExpiration = 0;
     const detailStateCopy = {
       ...SUBSCRIPTION_PLAN_ZERO_STATE,
@@ -122,7 +122,7 @@ describe('<SubscriptionExpirationBanner />', () => {
     };
 
     render(<ExpirationBannerWithContext detailState={detailStateCopy} />);
-    userEvent.click(screen.getByText('Contact customer support'));
+    userEvent.click(screen.getByText('Contact support'));
     expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       TEST_ENTERPRISE_CUSTOMER_UUID,
       'edx.ui.admin_portal.subscriptions.expiration.alert.support_cta.clicked',

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpirationModals.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpirationModals.test.jsx
@@ -89,7 +89,7 @@ describe('<SubscriptionExpirationModals />', () => {
       );
     });
 
-    test('handles customer support button click', () => {
+    test('handles support button click', () => {
       const agreementNetDaysUntilExpiration = 0;
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
@@ -97,7 +97,7 @@ describe('<SubscriptionExpirationModals />', () => {
       };
 
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
-      userEvent.click(screen.getByText('Contact customer support'));
+      userEvent.click(screen.getByText('Contact support'));
       expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
         TEST_ENTERPRISE_CUSTOMER_UUID,
         'edx.ui.admin_portal.subscriptions.expiration.modal.support_cta.clicked',
@@ -158,7 +158,7 @@ describe('<SubscriptionExpirationModals />', () => {
       );
     });
 
-    test('handles customer support button click', () => {
+    test('handles support button click', () => {
       const agreementNetDaysUntilExpiration = 0;
       const detailStateCopy = {
         ...SUBSCRIPTION_PLAN_ZERO_STATE,
@@ -166,7 +166,7 @@ describe('<SubscriptionExpirationModals />', () => {
       };
 
       render(<ExpirationModalsWithContext detailState={detailStateCopy} />);
-      userEvent.click(screen.getByText('Contact customer support'));
+      userEvent.click(screen.getByText('Contact support'));
       expect(enterpriseUtils.sendEnterpriseTrackEvent).toHaveBeenCalledWith(
         TEST_ENTERPRISE_CUSTOMER_UUID,
         'edx.ui.admin_portal.subscriptions.expiration.modal.support_cta.clicked',

--- a/src/components/subscriptions/tests/expiration/SubscriptionExpiredModal.test.jsx
+++ b/src/components/subscriptions/tests/expiration/SubscriptionExpiredModal.test.jsx
@@ -45,6 +45,6 @@ describe('<SubscriptionExpiredModal />', () => {
 
   test('support button is rendered', async () => {
     render(<ExpiredModalWithContext detailState={detailStateCopy(0)} />);
-    expect(screen.queryByText('Contact customer support')).toBeTruthy();
+    expect(screen.queryByText('Contact support')).toBeTruthy();
   });
 });


### PR DESCRIPTION
ENT-5568 - eliminate the 'customer' portion of this button label.

https://openedx.atlassian.net/browse/ENT-5568

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots

# Screenshots

Expired RIGHT NOW:
![image](https://user-images.githubusercontent.com/2307986/160435862-ece5b1ce-c0a8-4a48-9abc-fc32e47e6a3c.png)

Expiring very soon:
![image](https://user-images.githubusercontent.com/2307986/160435504-9464223a-d768-4458-a8ea-31f6252d20d3.png)

Expiring kinda soon:
![image](https://user-images.githubusercontent.com/2307986/160435681-5853ced1-f1dd-4d96-b79f-5a8b480915ca.png)

Expiring later:
![image](https://user-images.githubusercontent.com/2307986/160435779-b7f74665-4676-49b4-964f-4d8f03e946ca.png)

