### PR TITLE
ENT-6480: fix: Added API errors when server returns an error.

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.test.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.test.jsx
@@ -306,4 +306,40 @@ describe('<ReportingConfigForm />', () => {
     await act(() => flushPromises());
     expect(createConfig.mock.calls[0][0].get('enterprise_customer_id')).toEqual(enterpriseCustomerUuid);
   });
+  it('handles API response errors correctly.', async () => {
+    defaultConfig.pgpEncryptionKey = 'invalid-key';
+    const mock = jest.fn();
+
+    const wrapper = mount((
+      <ReportingConfigForm
+        config={defaultConfig}
+        createConfig={createConfig}
+        updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
+        reportingConfigTypes={reportingConfigTypes}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />
+    ));
+    wrapper.instance().setState = mock;
+
+    const formData = new FormData();
+    Object.entries(defaultConfig).forEach(([key, value]) => {
+      formData.append(key, value);
+    });
+    const errorResponse = {
+      data: {
+        pgp_encryption_key: ['Please enter a valid PGP encryption key.'],
+      },
+    };
+    wrapper.instance().handleAPIErrorResponse(errorResponse);
+    expect(mock).toHaveBeenCalled();
+
+    mock.mockClear();
+
+    wrapper.instance().handleAPIErrorResponse({});
+    expect(mock).not.toHaveBeenCalled();
+
+    wrapper.instance().handleAPIErrorResponse(null);
+    expect(mock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6480](https://2u-internal.atlassian.net/browse/ENT-6480)

__Description:__
We need to add validation to our Enterprise Reporting Configurations to ensure that the PGP encryption key is valid when saving. PGP keys are encoded in this example format.

Previously, errors returned by the API for PGP encryption key were not being shown on the field and user was not able to see what is wrong. With this change user will see the error message along with the highlighted field name. Same as errors shown by frontend validation code.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
