### PR TITLE
fix: ensure lint returns error on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "fedx-scripts webpack",
     "build:with-theme": "THEME=npm:@edx/brand-edx.org@latest npm run install-theme && fedx-scripts webpack",
     "check-types": "tsc --noemit",
-    "lint": "fedx-scripts eslint --ext .js --ext .jsx .; npm run check-types",
+    "lint": "fedx-scripts eslint --ext .js --ext .jsx . && npm run check-types",
     "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx --ext .tsx --ext .ts .",
     "precommit": "npm run lint",
     "prepublishOnly": "npm run build",

--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -67,7 +67,7 @@ describe('<Coupon />', () => {
       expect(coupon).toMatchSnapshot();
     });
 
-    it("without max uses", () => {
+    it('without max uses', () => {
       const coupon = renderer
         .create(
           <CouponWrapper
@@ -75,21 +75,21 @@ describe('<Coupon />', () => {
               ...initialCouponData,
               max_uses: null,
             }}
-          />
+          />,
         )
         .toJSON();
       expect(coupon).toMatchSnapshot();
     });
 
-    it("with error state", () => {
+    it('with error state', () => {
       const coupon = renderer
         .create(
           <CouponWrapper
             data={{
               ...initialCouponData,
-              errors: [{ code: "test-code", user_email: "test@example.com" }],
+              errors: [{ code: 'test-code', user_email: 'test@example.com' }],
             }}
-          />
+          />,
         )
         .toJSON();
       expect(coupon).toMatchSnapshot();
@@ -138,7 +138,7 @@ describe('<Coupon />', () => {
         <CouponWrapper
           onExpand={mockOnExpandOrOnCollapse}
           onCollapse={mockOnExpandOrOnCollapse}
-        />
+        />,
       );
 
       fireEvent.keyDown(screen.getByRole('button'), { key: 'A', code: 'KeyA' });


### PR DESCRIPTION
Noticed this was failing lint when reviewing https://github.com/openedx/frontend-app-admin-portal/pull/1013. The CI was running but the lint command in `package.json` was written in a way that wouldn't fail CI on lint failure. This PR updates the `package.json` to fail CI when lint fails, and fixes the lint errors in `Coupon.test.jsx` (by running `npm run lint:fix`)