### PR TITLE
feat: updates groups help center link

### DIFF
--- a/src/components/PeopleManagement/AddMembersModal/AddMembersModalContent.jsx
+++ b/src/components/PeopleManagement/AddMembersModal/AddMembersModalContent.jsx
@@ -14,6 +14,7 @@ import FileUpload from '../../learner-credit-management/invite-modal/FileUpload'
 import { EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY, isInviteEmailAddressesInputValueValid } from '../../learner-credit-management/cards/data';
 import EnterpriseCustomerUserDatatable from '../EnterpriseCustomerUserDatatable';
 import { useEnterpriseLearners } from '../../learner-credit-management/data';
+import { HELP_CENTER_URL } from '../constants';
 
 const AddMembersModalContent = ({
   onEmailAddressesChange,
@@ -94,14 +95,17 @@ const AddMembersModalContent = ({
       </h3>
       <Row>
         <Col>
-          <p>Only members registered with your organization can be added to your group. &nbsp;
-            <Hyperlink
-              destination="www.edX.org"
-              target="_blank"
-            >
-              Learn more.
-            </Hyperlink>
-          </p>
+          <FormattedMessage
+            id="people.management.add.members.modal"
+            defaultMessage="Only members registered with your organization can be added to a group."
+            description="Subtitle for the add members modal"
+          />
+          <Hyperlink
+            destination={HELP_CENTER_URL}
+            target="_blank"
+          >
+            Learn more.
+          </Hyperlink>
           <h4 className="mt-4 text-uppercase">Group Name</h4>
           <p className="font-weight-bold lead">{groupName}</p>
         </Col>

--- a/src/components/PeopleManagement/CreateGroupModalContent.jsx
+++ b/src/components/PeopleManagement/CreateGroupModalContent.jsx
@@ -4,7 +4,7 @@ import React, {
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import {
-  Col, Container, Form, Row,
+  Col, Container, Form, Hyperlink, Row,
 } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
@@ -12,7 +12,7 @@ import InviteModalSummary from '../learner-credit-management/invite-modal/Invite
 import InviteSummaryCount from '../learner-credit-management/invite-modal/InviteSummaryCount';
 import FileUpload from '../learner-credit-management/invite-modal/FileUpload';
 import { EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY, isInviteEmailAddressesInputValueValid } from '../learner-credit-management/cards/data';
-import { MAX_LENGTH_GROUP_NAME } from './constants';
+import { MAX_LENGTH_GROUP_NAME, HELP_CENTER_URL } from './constants';
 import EnterpriseCustomerUserDatatable from './EnterpriseCustomerUserDatatable';
 import { useEnterpriseLearners } from '../learner-credit-management/data';
 
@@ -114,6 +114,17 @@ const CreateGroupModalContent = ({
       </h3>
       <Row>
         <Col>
+          <FormattedMessage
+            id="people.management.create.groups.modal"
+            defaultMessage="Only members registered with your organization can be added to a group."
+            description="Subtitle for the create group modal"
+          />
+          <Hyperlink
+            destination={HELP_CENTER_URL}
+            target="_blank"
+          >
+            Learn more.
+          </Hyperlink>
           <h4 className="mt-4">Name your group</h4>
           <Form.Control
             value={groupName}

--- a/src/components/PeopleManagement/LearnerNotInOrgErrorState.jsx
+++ b/src/components/PeopleManagement/LearnerNotInOrgErrorState.jsx
@@ -4,6 +4,7 @@ import {
 } from '@openedx/paragon';
 import classNames from 'classnames';
 import { Error } from '@openedx/paragon/icons';
+import { HELP_CENTER_URL } from './constants';
 
 const LearnerNotInOrgErrorState = () => (
   <Stack gap={2.5} className="mb-4">
@@ -20,7 +21,7 @@ const LearnerNotInOrgErrorState = () => (
             <div className="h4 mb-0">Some people can&apos;t be added.</div>
             <span className="small">Check that all people in the file are registered with your organization.
               <Hyperlink
-                destination="https://www.edx.org"
+                destination={HELP_CENTER_URL}
                 target="_blank"
               >
                 Learn more

--- a/src/components/PeopleManagement/constants.js
+++ b/src/components/PeopleManagement/constants.js
@@ -18,3 +18,5 @@ export const peopleManagementQueryKeys = {
 };
 
 export const MAX_INITIAL_LEARNER_EMAILS_DISPLAYED_COUNT = 15;
+
+export const HELP_CENTER_URL = 'https://enterprise-support.edx.org/s/topic/0TORc000000GBQvOAO/admin-experience';

--- a/src/components/PeopleManagement/tests/AddMembersModal.test.jsx
+++ b/src/components/PeopleManagement/tests/AddMembersModal.test.jsx
@@ -163,6 +163,8 @@ describe('<AddMembersModal />', () => {
     expect(screen.getByText('Add')).toBeInTheDocument();
     expect(screen.getByText('Cancel')).toBeInTheDocument();
     expect(screen.getByText('test-group-name')).toBeInTheDocument();
+    expect(screen.getByText('Only members registered with your organization can be added to a group.')).toBeInTheDocument();
+    expect(screen.getByText('Learn more.').getAttribute('href')).toBe('https://enterprise-support.edx.org/s/topic/0TORc000000GBQvOAO/admin-experience');
 
     // renders datatable
     expect(screen.getByText('Member details')).toBeInTheDocument();

--- a/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
+++ b/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
@@ -153,7 +153,8 @@ describe('<CreateGroupModal />', () => {
     expect(screen.getByText('Upload a CSV file or select members to get started.')).toBeInTheDocument();
     expect(screen.getByText('Create')).toBeInTheDocument();
     expect(screen.getByText('Cancel')).toBeInTheDocument();
-
+    expect(screen.getByText('Only members registered with your organization can be added to a group.')).toBeInTheDocument();
+    expect(screen.getByText('Learn more.').getAttribute('href')).toBe('https://enterprise-support.edx.org/s/topic/0TORc000000GBQvOAO/admin-experience');
     // renders datatable
     expect(screen.getByText('Member details')).toBeInTheDocument();
     expect(screen.getByText('Joined organization')).toBeInTheDocument();


### PR DESCRIPTION
## Description

Updates links to the groups help center doc and adds a subtitle in the `Create group` modal.
[JIRA](https://2u-internal.atlassian.net/browse/ENT-9950)

![Screenshot 2025-02-04 at 2 50 17 PM](https://github.com/user-attachments/assets/1427265f-6008-4b37-8fae-b3400b00fb7e)

## Testing
1. checkout branch and run `npm run start:stage`
2. navigate to https://localhost.stage.edx.org:1991/alc-general/admin/people-management and click on `Create group`. verify that you see the subtitle and clicking on the `Learn more` link takes you to the help center.
3. Upload a CSV file with a random email in the Create group modal so that an error card will appear. Click on the the link and verify that it navigates you to the help center.
4. Navigate to a groups detail page and click on `Add members`. Verify that clicking on the `Learn more` link in that modal takes you to the help center.


- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
