### PR TITLE
fix: fixes undefined group uuid

### DIFF
--- a/src/components/PeopleManagement/LearnerDetailPage/LearnerDetailPage.jsx
+++ b/src/components/PeopleManagement/LearnerDetailPage/LearnerDetailPage.jsx
@@ -22,7 +22,7 @@ import { transformLearnerContentAssignment } from '../utils';
 
 const LearnerDetailPage = ({ enterpriseUUID }) => {
   const { enterpriseSlug, groupUuid, learnerId } = useParams();
-  const { data: enterpriseGroup } = useEnterpriseGroupUuid(groupUuid);
+  const { data: enterpriseGroup } = useEnterpriseGroupUuid(groupUuid, { queryOptions: { enabled: !!groupUuid } });
 
   const { isLoading, learnerData } = useEnterpriseLearnerData(enterpriseUUID, learnerId);
 

--- a/src/components/PeopleManagement/data/hooks/useEnterpriseGroupUuid.js
+++ b/src/components/PeopleManagement/data/hooks/useEnterpriseGroupUuid.js
@@ -19,6 +19,7 @@ const getEnterpriseGroupUuid = async ({ groupUuid }) => {
 const useEnterpriseGroupUuid = (groupUuid, { queryOptions } = {}) => useQuery({
   queryKey: peopleManagementQueryKeys.group(groupUuid),
   queryFn: () => getEnterpriseGroupUuid({ groupUuid }),
+  enabled: !!groupUuid,
   ...queryOptions,
 });
 


### PR DESCRIPTION
# For all changes
https://2u-internal.atlassian.net/browse/ENT-10319

Ensures we only call the `useEnterpriseGroupUuid` hook when `groupUuid` exists in the url param.

Testing instructions:

1. inspect the network tab at this link https://localhost.stage.edx.org:1991/aj-test-co/admin/people-management and confirm that you do not see any calls to the groups endpoint when navigating to a learner profile page from the People Management page. 

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
