### PR TITLE
feat: display saved_for_later course enrollments

### DIFF
--- a/src/components/PeopleManagement/LearnerDetailPage/CourseEnrollments.jsx
+++ b/src/components/PeopleManagement/LearnerDetailPage/CourseEnrollments.jsx
@@ -12,7 +12,7 @@ const CourseEnrollments = ({ enrollments, isLoading }) => {
     description: 'Message displayed when a learner has no course enrollments',
   });
 
-  const enrollmentTypes = ['assignmentsForDisplay', 'inProgress', 'upcoming', 'completed'];
+  const enrollmentTypes = ['assignmentsForDisplay', 'inProgress', 'upcoming', 'savedForLater', 'completed'];
   const flattenedEnrollments = enrollmentTypes.flatMap(type => enrollments?.[type] || []);
   const hasEnrollments = flattenedEnrollments.length > 0;
 
@@ -60,6 +60,7 @@ CourseEnrollments.propTypes = {
     completed: PropTypes.arrayOf(enrollmentShape),
     inProgress: PropTypes.arrayOf(enrollmentShape),
     upcoming: PropTypes.arrayOf(enrollmentShape),
+    savedForLater: PropTypes.arrayOf(enrollmentShape),
     assignmentsForDisplay: PropTypes.arrayOf(enrollmentShape),
   }).isRequired,
   isLoading: PropTypes.bool.isRequired,

--- a/src/components/PeopleManagement/LearnerDetailPage/EnrollmentCard.jsx
+++ b/src/components/PeopleManagement/LearnerDetailPage/EnrollmentCard.jsx
@@ -23,6 +23,9 @@ const EnrollmentCard = ({ enrollment, enterpriseSlug }) => {
       case 'upcoming': {
         return (<Badge variant="info">Upcoming</Badge>);
       }
+      case 'saved_for_later': {
+        return (<Badge variant="dark">Saved for later</Badge>);
+      }
       default: {
         return (<Badge variant="info">Assigned</Badge>);
       }

--- a/src/components/PeopleManagement/tests/CourseEnrollments.test.jsx
+++ b/src/components/PeopleManagement/tests/CourseEnrollments.test.jsx
@@ -41,6 +41,14 @@ const mockEnrollments = {
       courseRunStatus: 'completed',
     },
   ],
+  savedForLater: [
+    {
+      uuid: '5',
+      courseKey: 'course-5',
+      displayName: 'Course 5',
+      courseRunStatus: 'saved_for_later',
+    },
+  ],
   assignmentsForDisplay: [
     {
       uuid: '4',
@@ -84,29 +92,36 @@ describe('CourseEnrollments', () => {
   it('renders in-progress enrollments', () => {
     renderComponent({ enrollments: mockEnrollments, isLoading: false });
     const enrollmentCards = screen.getAllByTestId('enrollment-card');
-    expect(enrollmentCards).toHaveLength(4);
+    expect(enrollmentCards).toHaveLength(5);
     expect(screen.getByText('Course 1')).toBeInTheDocument();
   });
 
   it('renders upcoming enrollments', () => {
     renderComponent({ enrollments: mockEnrollments, isLoading: false });
     const enrollmentCards = screen.getAllByTestId('enrollment-card');
-    expect(enrollmentCards).toHaveLength(4);
+    expect(enrollmentCards).toHaveLength(5);
     expect(screen.getByText('Course 2')).toBeInTheDocument();
   });
 
   it('renders completed enrollments', () => {
     renderComponent({ enrollments: mockEnrollments, isLoading: false });
     const enrollmentCards = screen.getAllByTestId('enrollment-card');
-    expect(enrollmentCards).toHaveLength(4);
+    expect(enrollmentCards).toHaveLength(5);
     expect(screen.getByText('Course 3')).toBeInTheDocument();
   });
 
   it('renders assigned enrollments', () => {
     renderComponent({ enrollments: mockEnrollments, isLoading: false });
     const enrollmentCards = screen.getAllByTestId('enrollment-card');
-    expect(enrollmentCards).toHaveLength(4);
+    expect(enrollmentCards).toHaveLength(5);
     expect(screen.getByText('Course 4')).toBeInTheDocument();
+  });
+
+  it('renders saved for later enrollments', () => {
+    renderComponent({ enrollments: mockEnrollments, isLoading: false });
+    const enrollmentCards = screen.getAllByTestId('enrollment-card');
+    expect(enrollmentCards).toHaveLength(5);
+    expect(screen.getByText('Course 5')).toBeInTheDocument();
   });
 
   it('renders enrollments header', () => {


### PR DESCRIPTION
# For all changes

https://2u-internal.atlassian.net/browse/ENT-10400

Display `saved_for_later` course enrollments in the learner profile view. 

<img width="1315" alt="Screenshot 2025-04-30 at 7 54 48 AM" src="https://github.com/user-attachments/assets/29645729-be5c-4fd9-929c-4da55f7e649a" />


Testing Instructions:
1. Navigate to a learner's profile view https://localhost.stage.edx.org:1991/aj-test-co/admin/people-management/learner-detail/5264635 and verify that you can see their courses that are saved for later.

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
