### PR TITLE
[ENT-10539] Reintroduced granularity and calculation filters

### DIFF
--- a/src/components/AdvanceAnalyticsV2.0/AnalyticsFilters.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/AnalyticsFilters.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Form, IconButton, Icon } from '@openedx/paragon';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
+import { GRANULARITY, CALCULATION } from './data/constants';
 
 export const DEFAULT_GROUP = '';
 
@@ -11,6 +12,10 @@ const AnalyticsFilters = ({
   setStartDate,
   endDate,
   setEndDate,
+  granularity,
+  setGranularity,
+  calculation,
+  setCalculation,
   groupUUID,
   setGroupUUID,
   currentDate,
@@ -49,46 +54,8 @@ const AnalyticsFilters = ({
 
       {!collapsed && (
         <>
-          <div className="row filter-container mt-3">
-            <div className="col-3">
-              <Form.Group>
-                <Form.Label className="font-weight-normal">
-                  <FormattedMessage
-                    id="advance.analytics.date.filter.start.date"
-                    defaultMessage="Start date"
-                    description="Advance analytics Start date filter label"
-                  />
-                </Form.Label>
-                <Form.Control
-                  controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
-                  type="date"
-                  value={startDate || data?.minEnrollmentDate || ''}
-                  min={data?.minEnrollmentDate || ''}
-                  onChange={(e) => setStartDate(e.target.value)}
-                  disabled={isFetching}
-                />
-              </Form.Group>
-            </div>
-            <div className="col-3">
-              <Form.Group>
-                <Form.Label className="font-weight-normal">
-                  <FormattedMessage
-                    id="advance.analytics.date.filter.end.date"
-                    defaultMessage="End date"
-                    description="Advance analytics End date filter label"
-                  />
-                </Form.Label>
-                <Form.Control
-                  controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
-                  type="date"
-                  value={endDate || currentDate || ''}
-                  max={currentDate || ''}
-                  onChange={(e) => setEndDate(e.target.value)}
-                  disabled={isFetching}
-                />
-              </Form.Group>
-            </div>
-            <div className="col-3">
+          <div className="row filter-container mt-2">
+            <div className="col">
               <Form.Group>
                 <Form.Label className="font-weight-normal">
                   <FormattedMessage
@@ -107,9 +74,141 @@ const AnalyticsFilters = ({
                 </Form.Control>
               </Form.Group>
             </div>
+            <div className="col">
+              <Form.Group>
+                <Form.Label className="font-weight-normal">
+                  <FormattedMessage
+                    id="advance.analytics.date.filter.start.date"
+                    defaultMessage="Start date"
+                    description="Advance analytics Start date filter label"
+                  />
+                </Form.Label>
+                <Form.Control
+                  controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
+                  type="date"
+                  value={startDate || data?.minEnrollmentDate || ''}
+                  min={data?.minEnrollmentDate || ''}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  disabled={isFetching}
+                />
+              </Form.Group>
+            </div>
+            <div className="col">
+              <Form.Group>
+                <Form.Label className="font-weight-normal">
+                  <FormattedMessage
+                    id="advance.analytics.date.filter.end.date"
+                    defaultMessage="End date"
+                    description="Advance analytics End date filter label"
+                  />
+                </Form.Label>
+                <Form.Control
+                  controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
+                  type="date"
+                  value={endDate || currentDate || ''}
+                  max={currentDate || ''}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  disabled={isFetching}
+                />
+              </Form.Group>
+            </div>
+            <div className="col">
+              <Form.Group>
+                <Form.Label>
+                  <FormattedMessage
+                    id="advance.analytics.calculation.filter"
+                    defaultMessage="Calculation / Trends"
+                    description="Advance analytics Calculation filter label"
+                  />
+                </Form.Label>
+                <Form.Control
+                  controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
+                  as="select"
+                  value={calculation}
+                  onChange={(e) => setCalculation(e.target.value)}
+                  disabled={isFetching}
+                >
+                  <option value={CALCULATION.TOTAL}>
+                    {intl.formatMessage({
+                      id: 'advance.analytics.calculation.filter.option.total',
+                      defaultMessage: 'Total',
+                      description: 'Advance analytics calculation filter total option',
+                    })}
+                  </option>
+                  <option value={CALCULATION.RUNNING_TOTAL}>
+                    {intl.formatMessage({
+                      id: 'advance.analytics.calculation.filter.option.running.total',
+                      defaultMessage: 'Running Total',
+                      description: 'Advance analytics calculation filter running total option',
+                    })}
+                  </option>
+                  <option value={CALCULATION.MOVING_AVERAGE_3_PERIODS}>
+                    {intl.formatMessage({
+                      id: 'advance.analytics.calculation.filter.option.average.3',
+                      defaultMessage: 'Moving Average (3 Period)',
+                      description: 'Advance analytics calculation filter moving average 3 period option',
+                    })}
+                  </option>
+                  <option value={CALCULATION.MOVING_AVERAGE_7_PERIODS}>
+                    {intl.formatMessage({
+                      id: 'advance.analytics.calculation.filter.option.average.7',
+                      defaultMessage: 'Moving Average (7 Period)',
+                      description: 'Advance analytics calculation filter moving average 7 period option',
+                    })}
+                  </option>
+                </Form.Control>
+              </Form.Group>
+            </div>
           </div>
-          <div className="row filter-container mt-2 pb-2">
-            <div className="col-3" data-testid="group-select">
+          <div className="row filter-container">
+            <div className="col" data-testid="granularity-select">
+              <Form.Group>
+                <Form.Label>
+                  <FormattedMessage
+                    id="advance.analytics.filter.date.granularity"
+                    defaultMessage="Date granularity"
+                    description="Advance analytics data granularity filter label"
+                  />
+                </Form.Label>
+                <Form.Control
+                  controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
+                  as="select"
+                  value={granularity}
+                  onChange={(e) => setGranularity(e.target.value)}
+                  disabled={isFetching}
+                >
+                  <option value={GRANULARITY.DAILY}>
+                    {intl.formatMessage({
+                      id: 'advance.analytics.filter.granularity.option.daily',
+                      defaultMessage: 'Daily',
+                      description: 'Advance analytics granularity filter daily option',
+                    })}
+                  </option>
+                  <option value={GRANULARITY.WEEKLY}>
+                    {intl.formatMessage({
+                      id: 'advance.analytics.filter.granularity.option.weekly',
+                      defaultMessage: 'Weekly',
+                      description: 'Advance analytics granularity filter weekly option',
+                    })}
+                  </option>
+                  <option value={GRANULARITY.MONTHLY}>
+                    {intl.formatMessage({
+                      id: 'advance.analytics.filter.granularity.option.monthly',
+                      defaultMessage: 'Monthly',
+                      description: 'Advance analytics granularity filter monthly option',
+                    })}
+                  </option>
+                  <option value={GRANULARITY.QUARTERLY}>
+                    {intl.formatMessage({
+                      id: 'advance.analytics.filter.granularity.option.quarterly',
+                      defaultMessage: 'Quarterly',
+                      description: 'Advance analytics granularity filter quarterly option',
+                    })}
+                  </option>
+                </Form.Control>
+              </Form.Group>
+            </div>
+            <div className="col" data-testid="group-select">
               <Form.Group>
                 <Form.Label className="font-weight-normal">
                   <FormattedMessage
@@ -140,7 +239,7 @@ const AnalyticsFilters = ({
                 </Form.Control>
               </Form.Group>
             </div>
-            <div className="col-3">
+            <div className="col">
               <Form.Group>
                 <Form.Label className="font-weight-normal">
                   <FormattedMessage
@@ -159,7 +258,7 @@ const AnalyticsFilters = ({
                 </Form.Control>
               </Form.Group>
             </div>
-            <div className="col-3">
+            <div className="col">
               <Form.Group>
                 <Form.Label className="font-weight-normal">
                   <FormattedMessage
@@ -178,6 +277,8 @@ const AnalyticsFilters = ({
                 </Form.Control>
               </Form.Group>
             </div>
+          </div>
+          <div className="row filter-container pb-2">
             <div className="col-3">
               <Form.Group>
                 <Form.Label className="font-weight-normal">
@@ -209,6 +310,10 @@ AnalyticsFilters.propTypes = {
   setStartDate: PropTypes.func.isRequired,
   endDate: PropTypes.string,
   setEndDate: PropTypes.func.isRequired,
+  granularity: PropTypes.string.isRequired,
+  setGranularity: PropTypes.func.isRequired,
+  calculation: PropTypes.string.isRequired,
+  setCalculation: PropTypes.func.isRequired,
   groupUUID: PropTypes.string,
   setGroupUUID: PropTypes.func.isRequired,
   currentDate: PropTypes.string.isRequired,

--- a/src/components/AdvanceAnalyticsV2.0/AnalyticsPage.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/AnalyticsPage.jsx
@@ -7,13 +7,14 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import Hero from '../Hero';
 import Engagements from './tabs/Engagements';
 import { useEnterpriseAnalyticsAggregatesData } from './data/hooks';
+import { GRANULARITY, CALCULATION } from './data/constants';
 import { useAllFlexEnterpriseGroups } from '../learner-credit-management/data';
 import { AnalyticsFiltersContext } from './AnalyticsFiltersContext';
 
 const AnalyticsPage = ({ enterpriseId }) => {
   const [activeTab, setActiveTab] = useState('engagements');
-  const [granularity, setGranularity] = useState('');
-  const [calculation, setCalculation] = useState('');
+  const [granularity, setGranularity] = useState(GRANULARITY.WEEKLY);
+  const [calculation, setCalculation] = useState(CALCULATION.TOTAL);
   const [groupUUID, setGroupUUID] = useState('');
   const [startDate, setStartDate] = useState();
   const [endDate, setEndDate] = useState();

--- a/src/components/AdvanceAnalyticsV2.0/styles/index.scss
+++ b/src/components/AdvanceAnalyticsV2.0/styles/index.scss
@@ -1,5 +1,5 @@
 .analytics-filter-container {
-  height: 284px;
+  height: 364px;
 }
 
 .analytics-filter-container.collapsed {

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Engagements.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Engagements.jsx
@@ -27,7 +27,9 @@ const Engagements = ({ enterpriseId }) => {
     endDate,
     setEndDate,
     granularity,
+    setGranularity,
     calculation,
+    setCalculation,
     groupUUID,
     setGroupUUID,
     currentDate,
@@ -105,6 +107,10 @@ const Engagements = ({ enterpriseId }) => {
           setStartDate={setStartDate}
           endDate={endDate}
           setEndDate={setEndDate}
+          granularity={granularity}
+          setGranularity={setGranularity}
+          calculation={calculation}
+          setCalculation={setCalculation}
           groupUUID={groupUUID}
           setGroupUUID={setGroupUUID}
           currentDate={currentDate}

--- a/src/components/AdvanceAnalyticsV2.0/tests/AnalyticsFilters.test.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tests/AnalyticsFilters.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import AnalyticsFilters from '../AnalyticsFilters';
+import { GRANULARITY, CALCULATION } from '../data/constants';
 
 const mockSetStartDate = jest.fn();
 const mockSetEndDate = jest.fn();
@@ -15,6 +16,9 @@ const mockGroups = [
   { uuid: 'group-1', name: 'Group 1' },
   { uuid: 'group-2', name: 'Group 2' },
 ];
+
+const mockSetGranularity = jest.fn();
+const mockSetCalculation = jest.fn();
 
 describe('AnalyticsFilters Component', () => {
   beforeEach(() => {
@@ -33,6 +37,10 @@ describe('AnalyticsFilters Component', () => {
           groups={mockGroups}
           isFetching={false}
           isGroupsLoading={false}
+          granularity={GRANULARITY.WEEKLY}
+          setGranularity={mockSetGranularity}
+          calculation={CALCULATION.TOTAL}
+          setCalculation={mockSetCalculation}
         />,
       </IntlProvider>,
     );
@@ -41,9 +49,11 @@ describe('AnalyticsFilters Component', () => {
   test('should render the static text and filter inputs', () => {
     expect(screen.getByText(/Date range and filters/i)).toBeInTheDocument();
 
+    expect(screen.getByLabelText('Date range options')).toBeInTheDocument();
     expect(screen.getByLabelText('Start date')).toBeInTheDocument();
     expect(screen.getByLabelText('End date')).toBeInTheDocument();
-    expect(screen.getByLabelText('Date range options')).toBeInTheDocument();
+    expect(screen.getByLabelText('Calculation / Trends')).toBeInTheDocument();
+    expect(screen.getByLabelText('Date granularity')).toBeInTheDocument();
     expect(screen.getByLabelText('Filter by group')).toBeInTheDocument();
     expect(screen.getByLabelText('Filter by budget')).toBeInTheDocument();
     expect(screen.getByLabelText('Filter by course')).toBeInTheDocument();
@@ -95,5 +105,35 @@ describe('AnalyticsFilters Component', () => {
     fireEvent.click(toggleButton);
 
     expect(toggleButton).toHaveAttribute('aria-label', 'Collapse filters');
+  });
+
+  test('should call setGranularity when granularity is changed', () => {
+    const granularitySelect = screen.getByLabelText(/Date granularity/i);
+    fireEvent.change(granularitySelect, { target: { value: GRANULARITY.WEEKLY } });
+
+    expect(mockSetGranularity).toHaveBeenCalledWith(GRANULARITY.WEEKLY);
+  });
+
+  test('should call setCalculation when calculation is changed', () => {
+    const calculationSelect = screen.getByLabelText(/Calculation \/ Trends/i);
+    fireEvent.change(calculationSelect, { target: { value: CALCULATION.RUNNING_TOTAL } });
+
+    expect(mockSetCalculation).toHaveBeenCalledWith(CALCULATION.RUNNING_TOTAL);
+  });
+
+  test('should render the granularity options', () => {
+    const groupSelect = screen.getByLabelText(/Date granularity/i);
+    expect(groupSelect).toHaveTextContent('Daily');
+    expect(groupSelect).toHaveTextContent('Weekly');
+    expect(groupSelect).toHaveTextContent('Monthly');
+    expect(groupSelect).toHaveTextContent('Quarterly');
+  });
+
+  test('should render the calculation options', () => {
+    const groupSelect = screen.getByLabelText('Calculation / Trends');
+    expect(groupSelect).toHaveTextContent('Total');
+    expect(groupSelect).toHaveTextContent('Running Total');
+    expect(groupSelect).toHaveTextContent('Moving Average (3 Period)');
+    expect(groupSelect).toHaveTextContent('Moving Average (7 Period)');
   });
 });


### PR DESCRIPTION
**Ticket:**
https://2u-internal.atlassian.net/browse/ENT-10539

**Description:**
Reintroduce the granularity and calculation filters on the newly redesigned Engagement tab. These filters were part of the original implementation but were missed in the updated Figma designs.

**UI**
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/e3d1c8a3-89a2-4cef-8c5c-e66933f51868" />

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
