### PR TITLE
ENT-10531: Charts should always start from 0

### DIFF
--- a/src/components/AdvanceAnalyticsV2.0/charts/EmptyChart.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/charts/EmptyChart.jsx
@@ -29,8 +29,8 @@ const EmptyChart = ({ message }) => {
         yanchor: 'middle',
       },
     ],
-    xaxis: { visible: true },
-    yaxis: { visible: true },
+    xaxis: { visible: true, rangemode: 'tozero' },
+    yaxis: { visible: true, rangemode: 'tozero' },
     margin: {
       t: 0, b: 0, l: 0, r: 0,
     },

--- a/src/components/AdvanceAnalyticsV2.0/charts/EmptyChart.test.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/charts/EmptyChart.test.jsx
@@ -22,8 +22,8 @@ describe('EmptyChart', () => {
         yanchor: 'middle',
       },
     ],
-    xaxis: { visible: true },
-    yaxis: { visible: true },
+    xaxis: { visible: true, rangemode: 'tozero' },
+    yaxis: { visible: true, rangemode: 'tozero' },
     margin: {
       t: 0, b: 0, l: 0, r: 0,
     },

--- a/src/components/AdvanceAnalyticsV2.0/charts/LineChart.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/charts/LineChart.jsx
@@ -53,8 +53,8 @@ const LineChart = ({
     legend: {
       title: '', yanchor: 'top', y: 0.99, xanchor: 'right', x: 0.99, bgcolor: 'white',
     },
-    xaxis: { title: xAxisTitle },
-    yaxis: { title: yAxisTitle },
+    xaxis: { title: xAxisTitle, rangemode: 'tozero' },
+    yaxis: { title: yAxisTitle, rangemode: 'tozero' },
     autosize: true,
   };
 

--- a/src/components/AdvanceAnalyticsV2/charts/EmptyChart.jsx
+++ b/src/components/AdvanceAnalyticsV2/charts/EmptyChart.jsx
@@ -29,8 +29,8 @@ const EmptyChart = ({ message }) => {
         yanchor: 'middle',
       },
     ],
-    xaxis: { visible: true },
-    yaxis: { visible: true },
+    xaxis: { visible: true, rangemode: 'tozero' },
+    yaxis: { visible: true, rangemode: 'tozero' },
     margin: {
       t: 0, b: 0, l: 0, r: 0,
     },

--- a/src/components/AdvanceAnalyticsV2/charts/EmptyChart.test.jsx
+++ b/src/components/AdvanceAnalyticsV2/charts/EmptyChart.test.jsx
@@ -22,8 +22,8 @@ describe('EmptyChart', () => {
         yanchor: 'middle',
       },
     ],
-    xaxis: { visible: true },
-    yaxis: { visible: true },
+    xaxis: { visible: true, rangemode: 'tozero' },
+    yaxis: { visible: true, rangemode: 'tozero' },
     margin: {
       t: 0, b: 0, l: 0, r: 0,
     },

--- a/src/components/AdvanceAnalyticsV2/charts/LineChart.jsx
+++ b/src/components/AdvanceAnalyticsV2/charts/LineChart.jsx
@@ -39,8 +39,8 @@ const LineChart = ({
     legend: {
       title: '', yanchor: 'top', y: 0.99, xanchor: 'right', x: 0.99, bgcolor: 'white',
     },
-    xaxis: { title: xAxisTitle },
-    yaxis: { title: yAxisTitle },
+    xaxis: { title: xAxisTitle, rangemode: 'tozero' },
+    yaxis: { title: yAxisTitle, rangemode: 'tozero' },
     autosize: true,
   };
 


### PR DESCRIPTION
__Jira Ticket:__ [ENT-10531](https://2u-internal.atlassian.net/browse/ENT-10531)

This PR makes sure time series charts start from `(0, 0)`

<img width="1422" alt="Screenshot 2025-06-16 at 4 09 23 PM" src="https://github.com/user-attachments/assets/71540840-6368-4f77-ae7a-6d8facd41877" />

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
