### PR TITLE
chore: update CI to run on merges to master to ensure coverage updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: Default CI
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Currently, it appears that squash-and-merging a PR that drops the CodeCov project coverage in `master` does not update CodeCov with the commit SHA from the squashed commit on the `master` branch. As a result, the next PR(s) that open might be referencing a stale coverage report due to relying on the commit SHA from before the squash-and-merge, whereby CodeCov doesn't know the project coverage dropped on the latest `master`.

For example, [this PR](https://github.com/openedx/frontend-app-admin-portal/pull/1558) failed CodeCov's project coverage, seemingly because its using an incorrect base commit SHA that's different than the commit SHA from `master`. As a result, CodeCov thinks that PR is the cause of a drop in project coverage due to referencing the base commit SHA as `77d25360a8fdd550c3f6591945f3c47b6d93011d` vs `8d9e7a4f98b3e639df4636f7932b2a208defb4f2`.

To remedy this issue, these proposed changes update the `ci.yml` GitHub Action workflow to also run on commits to `master` so that `npm run test` and the CodeCov reporting is run on `master`'s commits after merging a PR, which should ensure CodeCov's base commit SHA for subsequent PRs is targeting the latest commit vs. a potentially stale commit.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
