### PR TITLE
feat: handle bnrEnabled subsidy configurations on settings tab

### DIFF
--- a/src/components/settings/SettingsAccessTab/data/hooks.ts
+++ b/src/components/settings/SettingsAccessTab/data/hooks.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+import { logError } from '@edx/frontend-platform/logging';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+
+import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
+
+export const useLearnerCreditBrowseAndRequest = (enterpriseUuid) => {
+  const [isLoadingPolicies, setIsLoadingPolicies] = useState(true);
+  const [hasBnrEnabledPolicy, setHasBnrEnabledPolicy] = useState(false);
+
+  const fetchPolicies = useCallback(async () => {
+    try {
+      setIsLoadingPolicies(true);
+      const response = await EnterpriseAccessApiService.listSubsidyAccessPolicies(enterpriseUuid);
+      const policies = camelCaseObject(response?.data?.results) || [];
+      const hasBnrPolicy = policies.some(policy => policy.bnrEnabled);
+      setHasBnrEnabledPolicy(hasBnrPolicy);
+    } catch (error) {
+      logError(error);
+    } finally {
+      setIsLoadingPolicies(false);
+    }
+  }, [enterpriseUuid]);
+
+  useEffect(() => {
+    if (enterpriseUuid) {
+      fetchPolicies();
+    }
+  }, [enterpriseUuid, fetchPolicies]);
+
+  return {
+    isLoadingPolicies,
+    hasBnrEnabledPolicy,
+  };
+};

--- a/src/components/settings/SettingsAccessTab/data/tests/hooks.test.tsx
+++ b/src/components/settings/SettingsAccessTab/data/tests/hooks.test.tsx
@@ -1,0 +1,211 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { logError } from '@edx/frontend-platform/logging';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import { useLearnerCreditBrowseAndRequest } from '../hooks';
+import EnterpriseAccessApiService from '../../../../../data/services/EnterpriseAccessApiService';
+import { queryClient } from '../../../../test/testUtils';
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  ...jest.requireActual('@edx/frontend-platform/logging'),
+  logError: jest.fn(),
+}));
+
+jest.mock('../../../../../data/services/EnterpriseAccessApiService');
+
+const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
+
+describe('useLearnerCreditBrowseAndRequest', () => {
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      <IntlProvider locale="en">
+        {children}
+      </IntlProvider>
+    </QueryClientProvider>
+  );
+
+  const listSubsidyAccessPoliciesSpy = jest.spyOn(EnterpriseAccessApiService, 'listSubsidyAccessPolicies');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should successfully fetch policies and detect BNR-enabled policy', async () => {
+    const mockPoliciesResponse = [
+      {
+        uuid: 'policy-1',
+        display_name: 'Policy 1',
+        bnr_enabled: false,
+      },
+      {
+        uuid: 'policy-2',
+        display_name: 'Policy 2',
+        bnr_enabled: true,
+      },
+    ];
+
+    listSubsidyAccessPoliciesSpy.mockResolvedValue({
+      data: {
+        results: mockPoliciesResponse,
+      },
+    });
+
+    const { result } = renderHook(
+      () => useLearnerCreditBrowseAndRequest(TEST_ENTERPRISE_UUID),
+      { wrapper },
+    );
+
+    expect(result.current.isLoadingPolicies).toBe(true);
+    expect(result.current.hasBnrEnabledPolicy).toBe(false);
+
+    await waitFor(() => {
+      expect(listSubsidyAccessPoliciesSpy).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingPolicies).toBe(false);
+      expect(result.current.hasBnrEnabledPolicy).toBe(true);
+    });
+  });
+
+  it('should successfully fetch policies but find no BNR-enabled policies', async () => {
+    const mockPoliciesResponse = [
+      {
+        uuid: 'policy-1',
+        display_name: 'Policy 1',
+        bnr_enabled: false,
+      },
+      {
+        uuid: 'policy-2',
+        display_name: 'Policy 2',
+        bnr_enabled: false,
+      },
+    ];
+
+    listSubsidyAccessPoliciesSpy.mockResolvedValue({
+      data: {
+        results: mockPoliciesResponse,
+      },
+    });
+
+    const { result } = renderHook(
+      () => useLearnerCreditBrowseAndRequest(TEST_ENTERPRISE_UUID),
+      { wrapper },
+    );
+
+    expect(result.current.isLoadingPolicies).toBe(true);
+    expect(result.current.hasBnrEnabledPolicy).toBe(false);
+
+    await waitFor(() => {
+      expect(listSubsidyAccessPoliciesSpy).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingPolicies).toBe(false);
+      expect(result.current.hasBnrEnabledPolicy).toBe(false);
+    });
+  });
+
+  it('should handle empty policies response', async () => {
+    listSubsidyAccessPoliciesSpy.mockResolvedValue({
+      data: {
+        results: [],
+      },
+    });
+
+    const { result } = renderHook(
+      () => useLearnerCreditBrowseAndRequest(TEST_ENTERPRISE_UUID),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(listSubsidyAccessPoliciesSpy).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingPolicies).toBe(false);
+      expect(result.current.hasBnrEnabledPolicy).toBe(false);
+    });
+  });
+
+  it('should handle API error and log the error', async () => {
+    const mockError = new Error('API request failed');
+    listSubsidyAccessPoliciesSpy.mockRejectedValue(mockError);
+
+    const { result } = renderHook(
+      () => useLearnerCreditBrowseAndRequest(TEST_ENTERPRISE_UUID),
+      { wrapper },
+    );
+
+    expect(result.current.isLoadingPolicies).toBe(true);
+    expect(result.current.hasBnrEnabledPolicy).toBe(false);
+
+    await waitFor(() => {
+      expect(listSubsidyAccessPoliciesSpy).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+    });
+
+    await waitFor(() => {
+      expect(logError).toHaveBeenCalledWith(mockError);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingPolicies).toBe(false);
+      expect(result.current.hasBnrEnabledPolicy).toBe(false);
+    });
+  });
+
+  it('should not fetch policies when enterpriseUuid is not provided', () => {
+    const { result } = renderHook(
+      () => useLearnerCreditBrowseAndRequest(null),
+      { wrapper },
+    );
+
+    expect(result.current.isLoadingPolicies).toBe(true);
+    expect(result.current.hasBnrEnabledPolicy).toBe(false);
+    expect(listSubsidyAccessPoliciesSpy).not.toHaveBeenCalled();
+  });
+
+  it('should refetch policies when enterpriseUuid changes', async () => {
+    const mockPoliciesResponse = [
+      {
+        uuid: 'policy-1',
+        display_name: 'Policy 1',
+        bnr_enabled: true,
+      },
+    ];
+
+    listSubsidyAccessPoliciesSpy.mockResolvedValue({
+      data: {
+        results: mockPoliciesResponse,
+      },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ enterpriseUuid }) => useLearnerCreditBrowseAndRequest(enterpriseUuid),
+      {
+        wrapper,
+        initialProps: { enterpriseUuid: TEST_ENTERPRISE_UUID },
+      },
+    );
+
+    await waitFor(() => {
+      expect(listSubsidyAccessPoliciesSpy).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingPolicies).toBe(false);
+    });
+
+    jest.clearAllMocks();
+    const NEW_ENTERPRISE_UUID = 'new-enterprise-uuid';
+
+    rerender({ enterpriseUuid: NEW_ENTERPRISE_UUID });
+
+    await waitFor(() => {
+      expect(listSubsidyAccessPoliciesSpy).toHaveBeenCalledWith(NEW_ENTERPRISE_UUID);
+    });
+
+    expect(listSubsidyAccessPoliciesSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessTab.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessTab.test.jsx
@@ -7,6 +7,7 @@ import SettingsAccessTab from '../index';
 import { SubsidyRequestsContext } from '../../../subsidy-requests';
 import { SUPPORTED_SUBSIDY_TYPES } from '../../../../data/constants/subsidyRequests';
 import { EnterpriseSubsidiesContext } from '../../../EnterpriseSubsidiesContext';
+import { useLearnerCreditBrowseAndRequest } from '../data/hooks';
 
 jest.mock('../SettingsAccessSubsidyTypeSelection', () => ({
   __esModule: true, // this property makes it work
@@ -41,6 +42,12 @@ jest.mock('../../../subsidy-request-management-alerts/NoAvailableLicensesBanner'
 jest.mock('../../../subsidy-request-management-alerts/NoAvailableCodesBanner', () => ({
   __esModule: true,
   default: jest.fn(() => 'NoAvailableCodesBanner'),
+}));
+jest.mock('../data/hooks', () => ({
+  useLearnerCreditBrowseAndRequest: jest.fn(() => ({
+    isLoadingPolicies: false,
+    hasBnrEnabledPolicy: false,
+  })),
 }));
 jest.mock('../../../../config');
 
@@ -241,6 +248,67 @@ describe('<SettingsAccessTab />', () => {
             enterpriseSubsidyTypesForRequests: [SUPPORTED_SUBSIDY_TYPES.coupon, SUPPORTED_SUBSIDY_TYPES.license],
           }
         }
+      />,
+    );
+
+    expect(screen.getByText('SettingsAccessConfiguredSubsidyType')).toBeInTheDocument();
+  });
+
+  it('should show skeleton when loading is true', () => {
+    useLearnerCreditBrowseAndRequest.mockReturnValue({
+      isLoadingPolicies: true,
+      hasBnrEnabledPolicy: false,
+    });
+
+    renderWithRouter(
+      <SettingsAccessTabWrapper
+        subsidyRequestConfigurationContextValue={{
+          subsidyRequestConfiguration: null,
+          updateSubsidyRequestConfiguration: jest.fn(),
+          enterpriseSubsidyTypesForRequests: [SUPPORTED_SUBSIDY_TYPES.budget, SUPPORTED_SUBSIDY_TYPES.license],
+        }}
+      />,
+    );
+
+    expect(document.querySelector('.react-loading-skeleton')).toBeTruthy();
+  });
+
+  it('should not render Manage course requests when hasBnrEnabledPolicy is true', () => {
+    useLearnerCreditBrowseAndRequest.mockReturnValue({
+      isLoadingPolicies: false,
+      hasBnrEnabledPolicy: true,
+    });
+
+    renderWithRouter(
+      <SettingsAccessTabWrapper
+        subsidyRequestConfigurationContextValue={{
+          subsidyRequestConfiguration: {
+            ...mockSubsidyRequestConfiguration,
+            subsidyType: SUPPORTED_SUBSIDY_TYPES.license,
+          },
+          updateSubsidyRequestConfiguration: jest.fn(),
+          enterpriseSubsidyTypesForRequests: [SUPPORTED_SUBSIDY_TYPES.budget],
+        }}
+        props={{ enableUniversalLink: true }}
+      />,
+    );
+
+    expect(screen.queryByText('Manage course requests')).not.toBeInTheDocument();
+  });
+
+  it('should render SettingsAccessConfiguredSubsidyType with budget type when hasBnrEnabledPolicy is true', () => {
+    useLearnerCreditBrowseAndRequest.mockReturnValue({
+      isLoadingPolicies: false,
+      hasBnrEnabledPolicy: true,
+    });
+
+    renderWithRouter(
+      <SettingsAccessTabWrapper
+        subsidyRequestConfigurationContextValue={{
+          subsidyRequestConfiguration: null,
+          updateSubsidyRequestConfiguration: jest.fn(),
+          enterpriseSubsidyTypesForRequests: [SUPPORTED_SUBSIDY_TYPES.budget, SUPPORTED_SUBSIDY_TYPES.license],
+        }}
       />,
     );
 

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -13,6 +13,11 @@ const messages = defineMessages({
     defaultMessage: 'Licenses',
     description: 'Subsidy type label for licenses',
   },
+  subsidyTypeBudget: {
+    id: 'adminPortal.settings.access.subsidyTypeSelection.budget',
+    defaultMessage: 'Learner Credit',
+    description: 'Subsidy type label for budget',
+  },
 });
 
 export const ACCESS_TAB = 'access';
@@ -107,6 +112,7 @@ export const SSO_CONFIG_POLLING_INTERVAL = 1000;
 export const SUBSIDY_TYPE_LABELS = {
   [SUPPORTED_SUBSIDY_TYPES.coupon]: messages.subsidyTypeCodes,
   [SUPPORTED_SUBSIDY_TYPES.license]: messages.subsidyTypeLicenses,
+  [SUPPORTED_SUBSIDY_TYPES.budget]: messages.subsidyTypeBudget,
 };
 
 export const DARK_COLOR = '#454545';

--- a/src/components/subsidy-requests/tests/SubsidyRequestsContext.test.jsx
+++ b/src/components/subsidy-requests/tests/SubsidyRequestsContext.test.jsx
@@ -76,7 +76,7 @@ describe('useSubsidyRequestsContext', () => {
       }),
     );
     expect(result.current.enterpriseSubsidyTypesForRequests).toEqual([
-      SUBSIDY_TYPES.license,
+      SUBSIDY_TYPES.budget, SUBSIDY_TYPES.license,
     ]);
   });
 });

--- a/src/data/constants/subsidyRequests.js
+++ b/src/data/constants/subsidyRequests.js
@@ -1,6 +1,7 @@
 export const SUPPORTED_SUBSIDY_TYPES = {
   coupon: 'coupon',
   license: 'license',
+  budget: 'budget',
 };
 
 export const SUBSIDY_REQUEST_STATUS = {


### PR DESCRIPTION
Ticket: [ENT-10647](https://2u-internal.atlassian.net/jira/software/c/projects/ENT/boards/868?selectedIssue=ENT-10647)
Description: Added the subsidy type ("Learner Credit") if we have a bnr enabled policy. Also, hid the "Manage Requests" section.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots

<img width="797" height="155" alt="image" src="https://github.com/user-attachments/assets/abcd2ea2-5dac-4ec9-9fe5-919d0c2d9b6a" />
