### PR TITLE
feat: Support filtering on activity tab for action status

### DIFF
--- a/src/components/learner-credit-management/ApprovedRequestActionsTableCell.jsx
+++ b/src/components/learner-credit-management/ApprovedRequestActionsTableCell.jsx
@@ -10,7 +10,7 @@ const ApprovedRequestActionsTableCell = ({ row }) => {
 
   // Check if the cancel and remind button should be shown for this row
   const shouldShowShowActionButtons = (
-    (original.lastActionStatus === 'waiting_for_learner' || original.requestStatus === 'approved')
+    (original.lastActionStatus === 'reminded' || original.requestStatus === 'approved')
   );
 
   // Don't render dropdown if no actions are available

--- a/src/components/learner-credit-management/BudgetDetailApprovedRequestTable.jsx
+++ b/src/components/learner-credit-management/BudgetDetailApprovedRequestTable.jsx
@@ -17,19 +17,14 @@ const FilterStatus = (rest) => (
 );
 
 const getRequestStatusDisplayName = (status) => {
-  if (status === 'waiting_for_learner') {
-    return 'Waiting for learner';
-  }
+  const statusDisplayMap = {
+    reminded: 'Waiting for learner',
+    approved: 'Approved',
+    pending: 'Pending',
+    refunded: 'Refunded',
+  };
 
-  if (status === 'refunded') {
-    return 'Refunded';
-  }
-
-  if (status === 'failed_cancellation') {
-    return 'Failed cancellation';
-  }
-
-  return status
+  return statusDisplayMap[status] || status
     .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');

--- a/src/components/learner-credit-management/CancelApprovedRequestModal.jsx
+++ b/src/components/learner-credit-management/CancelApprovedRequestModal.jsx
@@ -62,7 +62,7 @@ const CancelApprovedRequestModal = ({
         <p>
           <FormattedMessage
             id="lcm.budget.detail.page.approved.requests.cancel.approval.modal.body2"
-            defaultMessage="The learner will be notified that their approved request has been canceled. The funds associated with this request will move from 'assigned' back to 'available'."
+            defaultMessage="The learner will be notified that their approved request has been canceled. The funds associated with this request will move from 'pending' back to 'available'."
             description="Body text for the cancel approval modal which informs the user that the learner will be notified that the approval has been canceled."
           />
         </p>

--- a/src/components/learner-credit-management/RequestStatusTableCell.jsx
+++ b/src/components/learner-credit-management/RequestStatusTableCell.jsx
@@ -40,7 +40,8 @@ const RequestStatusTableCell = ({ enterpriseId, row }) => {
   // Currently we check both `lastActionErrorReason` and `lastActionStatus` which creates
   // confusion since status information comes from two different sources. The API should
   // be updated to return a single, unified status field to simplify this logic.
-  if (lastActionErrorReason === 'Failed: Cancellation') {
+
+  if (lastActionErrorReason === 'failed_cancellation') {
     return (
       <FailedCancellation
         learnerEmail={learnerEmail}
@@ -49,7 +50,7 @@ const RequestStatusTableCell = ({ enterpriseId, row }) => {
     );
   }
 
-  if (lastActionStatus === 'waiting_for_learner' || requestStatus === 'approved') {
+  if (lastActionStatus === 'reminded' || requestStatus === 'approved') {
     return (
       <WaitingForLearner
         learnerEmail={learnerEmail}

--- a/src/components/learner-credit-management/data/hooks/tests/useBnrSubsidyRequests.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/tests/useBnrSubsidyRequests.test.jsx
@@ -39,7 +39,7 @@ const mockApiResponse = {
         created: '2023-10-27T10:00:00Z',
         state: 'approved',
         latestAction: {
-          status: 'waiting for learner',
+          status: 'reminded',
           errorReason: null,
           created: '2023-10-27T10:00:00Z',
         },
@@ -71,11 +71,11 @@ const expectedTransformedData = [
     amount: 100,
     requestDate: 'Oct 27, 2023',
     requestStatus: 'approved',
-    lastActionStatus: 'waiting_for_learner',
+    lastActionStatus: 'reminded',
     lastActionDate: 'Oct 27, 2023',
     lastActionErrorReason: null,
     latestAction: {
-      status: 'waiting for learner',
+      status: 'reminded',
       errorReason: null,
       created: '2023-10-27T10:00:00Z',
     },
@@ -90,10 +90,10 @@ const expectedTransformedData = [
     requestStatus: 'approved',
     lastActionStatus: 'refunded',
     lastActionDate: 'Oct 27, 2023',
-    lastActionErrorReason: 'Payment failed',
+    lastActionErrorReason: 'failed_cancellation',
     latestAction: {
       status: 'refunded',
-      errorReason: 'Payment failed',
+      errorReason: 'failed_cancellation',
       created: '2023-10-27T11:00:00Z',
     },
   },
@@ -247,8 +247,8 @@ describe('useBnrSubsidyRequests', () => {
         {
           page: 1,
           page_size: 25,
-          search: 'test@example.com',
           state: 'approved,pending',
+          search: 'test@example.com',
         },
       );
     });
@@ -528,10 +528,24 @@ describe('applyFiltersToOptions', () => {
     });
   });
 
-  it('should not apply status filter when array is empty', () => {
+  it('should apply nested field filters correctly', () => {
+    const options = {};
+    applyFiltersToOptions([
+      { id: 'lastActionStatus', value: ['reminded', 'approved'] },
+      { id: 'lastActionErrorReason', value: ['failed_cancellation'] },
+    ], options);
+    expect(options).toEqual({
+      action_status: 'reminded,approved',
+      action_error_reason: 'failed_cancellation',
+    });
+  });
+
+  it('should not apply filters when values are empty', () => {
     const options = {};
     applyFiltersToOptions([
       { id: 'requestStatus', value: [] },
+      { id: 'requestDetails', value: '' },
+      { id: 'lastActionStatus', value: [] },
     ], options);
     expect(options).toEqual({});
   });

--- a/src/components/learner-credit-management/requests-tab/BnrRequestStatusCell.jsx
+++ b/src/components/learner-credit-management/requests-tab/BnrRequestStatusCell.jsx
@@ -11,6 +11,24 @@ const BnrRequestStatusCell = ({ row }) => {
   const recentAction = latestAction?.recentAction;
   const [target, setTarget] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Format error reasons for display
+  const formatErrorReason = (reason) => {
+    if (!reason) {
+      return null;
+    }
+
+    const errorReasonMap = {
+      failed_approval: 'Failed: Approval',
+      failed_cancellation: 'Failed: Cancellation',
+      failed_system: 'Failed: System Error',
+      failed_payment: 'Failed: Payment',
+      failed_enrollment: 'Failed: Enrollment',
+    };
+
+    return errorReasonMap[reason]
+      || reason.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(': ');
+  };
   const getStatusConfig = useMemo(() => {
     const statusConfigs = {
       requested: {
@@ -44,7 +62,8 @@ const BnrRequestStatusCell = ({ row }) => {
   };
 
   // Determine what to display in the chip
-  const displayText = errorReason || getStatusConfig.label;
+  const formattedErrorReason = formatErrorReason(errorReason);
+  const displayText = formattedErrorReason || getStatusConfig.label;
   const displayIcon = errorReason ? Error : getStatusConfig.icon;
   const displayVariant = errorReason ? 'dark' : '';
   const isClickable = !!errorReason;
@@ -66,7 +85,7 @@ const BnrRequestStatusCell = ({ row }) => {
 
       {errorReason && (
         <RequestFailureModal
-          errorReason={errorReason}
+          errorReason={formattedErrorReason}
           isOpen={isModalOpen}
           onClose={closeModal}
           target={target}

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -1894,12 +1894,12 @@ describe('<BudgetDetailPage />', () => {
     const mockRequestsWithDifferentStatuses = [
       {
         ...mockApprovedRequest,
-        lastActionStatus: 'waiting_for_learner',
+        lastActionStatus: 'reminded',
       },
       {
         ...createMockApprovedRequest(),
         lastActionStatus: 'refunded',
-        lastActionErrorReason: 'Failed: Cancellation',
+        lastActionErrorReason: 'failed_cancellation',
       },
       {
         ...createMockApprovedRequest(),


### PR DESCRIPTION
- Remove getLastActionStatus function, use API values directly
- Fix errorReason field access after camelCase transformation
- Add nested field filtering/sorting (action_status, action_error_reason)
- Implement configuration-driven filtering for maintainability
- Update status mappings (reminded vs waiting_for_learner)
- Fix BnrRequestStatusCell error display (failed_approval → "Failed: Approval")
- Add React.memo optimizations and fix deprecation warnings
- Update tests for new API structure

Maintains backward compatibility while enabling enhanced filtering capabilities.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
