### PR TITLE
feat: update action status handling to use keys instead of display value

### DIFF
--- a/src/components/learner-credit-management/ApprovedRequestActionsTableCell.jsx
+++ b/src/components/learner-credit-management/ApprovedRequestActionsTableCell.jsx
@@ -10,7 +10,7 @@ const ApprovedRequestActionsTableCell = ({ row }) => {
 
   // Check if the cancel and remind button should be shown for this row
   const shouldShowShowActionButtons = (
-    (original.lastActionStatus === 'waiting_for_learner' || original.requestStatus === 'approved')
+    (original.lastActionStatus === 'reminded' || original.requestStatus === 'approved')
   );
 
   // Don't render dropdown if no actions are available

--- a/src/components/learner-credit-management/BudgetDetailApprovedRequestTable.jsx
+++ b/src/components/learner-credit-management/BudgetDetailApprovedRequestTable.jsx
@@ -17,7 +17,7 @@ const FilterStatus = (rest) => (
 );
 
 const getRequestStatusDisplayName = (status) => {
-  if (status === 'waiting_for_learner') {
+  if (status === 'appoved' || status === 'reminded') {
     return 'Waiting for learner';
   }
 
@@ -29,8 +29,7 @@ const getRequestStatusDisplayName = (status) => {
     return 'Failed cancellation';
   }
 
-  return status
-    .split('_')
+  return status.split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
 };

--- a/src/components/learner-credit-management/CancelApprovedRequestModal.jsx
+++ b/src/components/learner-credit-management/CancelApprovedRequestModal.jsx
@@ -62,7 +62,7 @@ const CancelApprovedRequestModal = ({
         <p>
           <FormattedMessage
             id="lcm.budget.detail.page.approved.requests.cancel.approval.modal.body2"
-            defaultMessage="The learner will be notified that their approved request has been canceled. The funds associated with this request will move from 'assigned' back to 'available'."
+            defaultMessage="The learner will be notified that their approved request has been canceled. The funds associated with this request will move from 'pending' back to 'available'."
             description="Body text for the cancel approval modal which informs the user that the learner will be notified that the approval has been canceled."
           />
         </p>

--- a/src/components/learner-credit-management/RequestStatusTableCell.jsx
+++ b/src/components/learner-credit-management/RequestStatusTableCell.jsx
@@ -40,7 +40,7 @@ const RequestStatusTableCell = ({ enterpriseId, row }) => {
   // Currently we check both `lastActionErrorReason` and `lastActionStatus` which creates
   // confusion since status information comes from two different sources. The API should
   // be updated to return a single, unified status field to simplify this logic.
-  if (lastActionErrorReason === 'Failed: Cancellation') {
+  if (lastActionErrorReason === 'failed_cancellation') {
     return (
       <FailedCancellation
         learnerEmail={learnerEmail}
@@ -49,7 +49,7 @@ const RequestStatusTableCell = ({ enterpriseId, row }) => {
     );
   }
 
-  if (lastActionStatus === 'waiting_for_learner' || requestStatus === 'approved') {
+  if (lastActionStatus === 'reminded' || requestStatus === 'approved') {
     return (
       <WaitingForLearner
         learnerEmail={learnerEmail}

--- a/src/components/learner-credit-management/data/hooks/tests/useBnrSubsidyRequests.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/tests/useBnrSubsidyRequests.test.jsx
@@ -39,7 +39,7 @@ const mockApiResponse = {
         created: '2023-10-27T10:00:00Z',
         state: 'approved',
         latestAction: {
-          status: 'waiting for learner',
+          status: 'reminded',
           errorReason: null,
           created: '2023-10-27T10:00:00Z',
         },
@@ -71,11 +71,11 @@ const expectedTransformedData = [
     amount: 100,
     requestDate: 'Oct 27, 2023',
     requestStatus: 'approved',
-    lastActionStatus: 'waiting_for_learner',
+    lastActionStatus: 'reminded',
     lastActionDate: 'Oct 27, 2023',
     lastActionErrorReason: null,
     latestAction: {
-      status: 'waiting for learner',
+      status: 'reminded',
       errorReason: null,
       created: '2023-10-27T10:00:00Z',
     },

--- a/src/components/learner-credit-management/data/hooks/useBnrSubsidyRequests.js
+++ b/src/components/learner-credit-management/data/hooks/useBnrSubsidyRequests.js
@@ -63,8 +63,6 @@ export const applyFiltersToOptions = (filters, options) => {
   }
 };
 
-const getLastActionStatus = (latestAction) => latestAction?.status?.toLowerCase().replace(/\s+/g, '_');
-
 // Transform API response data to match DataTable the requirements
 const transformApiDataToTableData = (apiResults) => apiResults.map((item) => {
   const requestDate = new Date(item.created).toLocaleDateString('en-US', {
@@ -85,7 +83,7 @@ const transformApiDataToTableData = (apiResults) => apiResults.map((item) => {
     amount: item?.coursePrice || 0,
     requestDate,
     requestStatus: item?.state,
-    lastActionStatus: getLastActionStatus(item?.latestAction),
+    lastActionStatus: item?.latestAction?.status, // Direct assignment, no transformation
     lastActionErrorReason: item?.latestAction?.errorReason,
     lastActionDate,
     latestAction: item?.latestAction,

--- a/src/components/learner-credit-management/requests-tab/BnrRequestStatusCell.jsx
+++ b/src/components/learner-credit-management/requests-tab/BnrRequestStatusCell.jsx
@@ -11,6 +11,24 @@ const BnrRequestStatusCell = ({ row }) => {
   const recentAction = latestAction?.recentAction;
   const [target, setTarget] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Format error reasons for display
+  const formatErrorReason = (reason) => {
+    if (!reason) {
+      return null;
+    }
+
+    const errorReasonMap = {
+      failed_approval: 'Failed: Approval',
+      failed_cancellation: 'Failed: Cancellation',
+      failed_system: 'Failed: System Error',
+      failed_payment: 'Failed: Payment',
+      failed_enrollment: 'Failed: Enrollment',
+    };
+
+    return errorReasonMap[reason]
+      || reason.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(': ');
+  };
   const getStatusConfig = useMemo(() => {
     const statusConfigs = {
       requested: {
@@ -44,7 +62,8 @@ const BnrRequestStatusCell = ({ row }) => {
   };
 
   // Determine what to display in the chip
-  const displayText = errorReason || getStatusConfig.label;
+  const formattedErrorReason = formatErrorReason(errorReason);
+  const displayText = formattedErrorReason || getStatusConfig.label;
   const displayIcon = errorReason ? Error : getStatusConfig.icon;
   const displayVariant = errorReason ? 'dark' : '';
   const isClickable = !!errorReason;
@@ -66,7 +85,7 @@ const BnrRequestStatusCell = ({ row }) => {
 
       {errorReason && (
         <RequestFailureModal
-          errorReason={errorReason}
+          errorReason={formattedErrorReason}
           isOpen={isModalOpen}
           onClose={closeModal}
           target={target}

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -1822,7 +1822,11 @@ describe('<BudgetDetailPage />', () => {
 
     const mockFailedCancellationRequest = {
       ...mockApprovedRequest,
-      lastActionErrorReason: 'Failed: Cancellation',
+      lastActionErrorReason: 'failed_cancellation',
+      latestAction: {
+        ...mockApprovedRequest.latestAction,
+        errorReason: 'failed_cancellation',
+      },
     };
     useBnrSubsidyRequests.mockReturnValue({
       isLoading: false,
@@ -1894,12 +1898,12 @@ describe('<BudgetDetailPage />', () => {
     const mockRequestsWithDifferentStatuses = [
       {
         ...mockApprovedRequest,
-        lastActionStatus: 'waiting_for_learner',
+        lastActionStatus: 'reminded',
       },
       {
         ...createMockApprovedRequest(),
         lastActionStatus: 'refunded',
-        lastActionErrorReason: 'Failed: Cancellation',
+        lastActionErrorReason: 'failed_cancellation',
       },
       {
         ...createMockApprovedRequest(),


### PR DESCRIPTION
- Change status checks from 'waiting_for_learner' to 'reminded'
- Change error reason checks from 'Failed: Cancellation' to 'failed_cancellation'
- Remove status transformation in useBnrSubsidyRequests hook
- Add formatErrorReason function in BnrRequestStatusCell for display formatting
- Update status display mapping in BudgetDetailApprovedRequestTable
- Update modal text from 'assigned' to 'pending'
- Update test data to use new status format

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots

# Screenshot

<img width="1419" height="391" alt="Screenshot 2025-07-22 at 11 49 16 AM" src="https://github.com/user-attachments/assets/1ca1e41a-ce6e-44f5-8729-75121bf1f634" />
