### PR TITLE
Replace of injectIntl with useIntl() 3/4

### DIFF
--- a/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
+++ b/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
@@ -3,7 +3,7 @@ import { Alert, Button } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import {
   BROWSE_AND_REQUEST_ALERT_COOKIE_PREFIX,
@@ -18,7 +18,11 @@ import { ACCESS_TAB } from '../settings/data/constants';
  */
 export const generateBrowseAndRequestAlertCookieName = (enterpriseId) => `${BROWSE_AND_REQUEST_ALERT_COOKIE_PREFIX}-${enterpriseId}`;
 
-const NewFeatureAlertBrowseAndRequest = ({ enterpriseId, enterpriseSlug, intl }) => {
+const NewFeatureAlertBrowseAndRequest = ({
+  enterpriseId,
+  enterpriseSlug,
+}) => {
+  const intl = useIntl();
   const browseAndRequestAlertCookieName = generateBrowseAndRequestAlertCookieName(enterpriseId);
   const hideAlert = global.localStorage.getItem(browseAndRequestAlertCookieName);
 
@@ -68,7 +72,6 @@ const NewFeatureAlertBrowseAndRequest = ({ enterpriseId, enterpriseSlug, intl })
 NewFeatureAlertBrowseAndRequest.propTypes = {
   enterpriseId: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
-  intl: intlShape.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -76,4 +79,4 @@ const mapStateToProps = state => ({
   enterpriseSlug: state.portalConfiguration.enterpriseSlug,
 });
 
-export default connect(mapStateToProps)(injectIntl(NewFeatureAlertBrowseAndRequest));
+export default connect(mapStateToProps)(NewFeatureAlertBrowseAndRequest);

--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty, omit } from 'lodash-es';
 import {
@@ -8,7 +8,7 @@ import {
   Check, Close, Download, Error,
 } from '@openedx/paragon/icons';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import SFTPDeliveryMethodForm from './SFTPDeliveryMethodForm';
 import EmailDeliveryMethodForm from './EmailDeliveryMethodForm';
 import SUBMIT_STATES from '../../data/constants/formSubmissions';
@@ -40,38 +40,44 @@ const REQUIRED_NEW_EMAIL_FIELDS = [
 const MONTHLY_MAX = 31;
 const MONTHLY_MIN = 1;
 
-class ReportingConfigForm extends React.Component {
-  // eslint-disable-next-line react/state-in-constructor
-  state = {
-    frequency: this.props.config ? this.props.config.frequency : 'monthly',
-    deliveryMethod: this.props.config ? this.props.config.deliveryMethod : 'email',
-    invalidFields: {},
-    APIErrors: {},
-    active: this.props.config ? this.props.config.active : false,
-    enableCompression: this.props.config ? this.props.config.enableCompression : true,
-    submitState: SUBMIT_STATES.DEFAULT,
-    includeDate: this.props.config ? this.props.config.includeDate : true,
-  };
+const ReportingConfigForm = ({
+  config,
+  createConfig,
+  deleteConfig,
+  updateConfig,
+  reportingConfigTypes,
+  availableCatalogs,
+  enterpriseCustomerUuid,
+}) => {
+  const [frequency, setFrequency] = useState(config?.frequency || 'monthly');
+  const [deliveryMethod, setDeliveryMethod] = useState(config?.deliveryMethod || 'email');
+  const [invalidFields, setInvalidFields] = useState({});
+  const [APIErrors, setAPIErrors] = useState({});
+  const [active, setActive] = useState(config?.active ?? false);
+  const [enableCompression, setEnableCompression] = useState(config?.enableCompression ?? true);
+  const [submitState, setSubmitState] = useState(SUBMIT_STATES.DEFAULT);
+  const [includeDate, setIncludeDate] = useState(config?.includeDate ?? true);
 
+  const intl = useIntl();
   /**
    * Validates this form. If the form is invalid, it will return the fields
    * that were invalid. Otherwise, it will return an empty object.
    * @param {FormData} formData
    * @param {[String]} requiredFields
    */
-  validateReportingForm = (config, formData, requiredFields) => {
-    const invalidFields = requiredFields
+  const validateReportingForm = (configProps, formData, requiredFields) => {
+    const currentInvalidFields = requiredFields
       .filter(field => !formData.get(field))
       .reduce((prevFields, currField) => ({ ...prevFields, [currField]: true }), {});
 
     // Password is conditionally required only when pgp key will not be present
     // and delivery method is email
     if (!formData.get('pgpEncryptionKey') && formData.get('deliveryMethod') === 'email') {
-      if (!formData.get('encryptedPassword') && !config?.encryptedPassword) {
-        invalidFields.encryptedPassword = true;
+      if (!formData.get('encryptedPassword') && !configProps?.encryptedPassword) {
+        currentInvalidFields.encryptedPassword = true;
       }
     }
-    return invalidFields;
+    return currentInvalidFields;
   };
 
   /**
@@ -82,37 +88,33 @@ class ReportingConfigForm extends React.Component {
    * @param {Func} validationFunction -> to see and example of this,
    * check the <EmailDeliveryMethodForm />
    */
-  handleBlur = (e, validationFunction) => {
+  const handleBlur = (e, validationFunction) => {
     // One special case for email fields
     const field = e.target;
     const error = validationFunction ? validationFunction() : !field.value?.length;
-    this.setState((state) => ({
-      invalidFields: {
-        ...state.invalidFields,
-        [field.name]: error,
-      },
-      // Remove the field that changed from APIErrors. It will b validated again on the next API request/
-      APIErrors: {
-        ...omit(state.APIErrors, [field.name]),
-      },
+    setInvalidFields((prevInvalidFields) => ({
+      ...prevInvalidFields,
+      [field.name]: error,
+    }));
+    // Remove the field that changed from APIErrors. It will b validated again on the next API request/
+    setAPIErrors((prevAPIErrors) => ({
+      ...omit(prevAPIErrors, [field.name]),
     }));
   };
 
-  handleAPIErrorResponse = (response) => {
+  const handleAPIErrorResponse = (response) => {
     const responseData = response && camelCaseObject(response.data);
-    const invalidFields = {};
+    const invalidFieldsResponse = {};
 
     if (!isEmpty(responseData)) {
       // eslint-disable-next-line no-restricted-syntax
       for (const [key, value] of Object.entries(responseData)) {
-        [invalidFields[key]] = value;
+        [invalidFieldsResponse[key]] = value;
       }
 
-      this.setState((state) => ({
-        APIErrors: {
-          ...state.APIErrors,
-          ...invalidFields,
-        },
+      setAPIErrors((prevAPIErrors) => ({
+        ...prevAPIErrors,
+        ...invalidFieldsResponse,
       }));
     }
   };
@@ -120,63 +122,59 @@ class ReportingConfigForm extends React.Component {
   /**
    * attempt to submit the form data and show any error states or invalid fields.
    * @param {FormData} formData
-   * @param {*} config
+   * @param {*} configProps
    */
-  handleSubmit = async (formData, config) => {
-    await this.setState({ submitState: SUBMIT_STATES.PENDING });
+  const handleSubmit = async (formData, configProps) => {
+    await setSubmitState(SUBMIT_STATES.PENDING);
     let requiredFields = [];
-    formData.append('active', this.state.active);
-    formData.append('enableCompression', this.state.enableCompression);
-    formData.append('includeDate', this.state.includeDate);
+    formData.append('active', active);
+    formData.append('enableCompression', enableCompression);
+    formData.append('includeDate', includeDate);
     if (formData.get('deliveryMethod') === 'email') {
-      requiredFields = config ? [...REQUIRED_EMAIL_FIELDS] : [...REQUIRED_NEW_EMAIL_FIELDS];
+      requiredFields = configProps ? [...REQUIRED_EMAIL_FIELDS] : [...REQUIRED_NEW_EMAIL_FIELDS];
       // transform email field to match what the api is looking for
       const emails = formData.get('emailRaw').split('\n');
       emails.forEach(email => formData.append('email[]', email));
     } else {
       // Password field needs to be required only when creating a new configuration
-      requiredFields = config ? [...REQUIRED_SFTP_FIELDS] : [...REQUIRED_NEW_SFTP_FEILDS];
+      requiredFields = configProps ? [...REQUIRED_SFTP_FIELDS] : [...REQUIRED_NEW_SFTP_FEILDS];
     }
     // validate the form
-    const invalidFields = this.validateReportingForm(config, formData, requiredFields);
+    const currentInvalidFields = validateReportingForm(configProps, formData, requiredFields);
     // if there are invalid fields, reflect that in the UI
-    if (!isEmpty(invalidFields)) {
-      this.setState((state) => ({
-        invalidFields: {
-          ...state.invalidFields,
-          ...invalidFields,
-        },
-        submitState: SUBMIT_STATES.default,
+    if (!isEmpty(currentInvalidFields)) {
+      setInvalidFields((prevInvalidFields) => ({
+        ...prevInvalidFields,
+        ...currentInvalidFields,
       }));
+      setSubmitState(SUBMIT_STATES.DEFAULT);
       return;
     }
 
     // append the enterprise customer data if editing an already created reporting form
-    if (config) {
-      formData.append('uuid', config.uuid);
-      formData.append('enterprise_customer_id', config.enterpriseCustomer.uuid);
-      const err = await this.props.updateConfig(formData, config.uuid);
+    if (configProps) {
+      formData.append('uuid', configProps.uuid);
+      formData.append('enterprise_customer_id', configProps.enterpriseCustomer.uuid);
+      const err = await updateConfig(formData, configProps.uuid);
       if (err) {
-        this.setState({ submitState: SUBMIT_STATES.ERROR });
-        this.handleAPIErrorResponse(err.response);
+        setSubmitState(SUBMIT_STATES.ERROR);
+        handleAPIErrorResponse(err.response);
         return;
       }
     } else {
       // ...or create a new configuration
-      formData.append('enterprise_customer_id', this.props.enterpriseCustomerUuid);
-      const err = await this.props.createConfig(formData);
+      formData.append('enterprise_customer_id', enterpriseCustomerUuid);
+      const err = await createConfig(formData);
       if (err) {
-        this.setState({ submitState: SUBMIT_STATES.ERROR });
-        this.handleAPIErrorResponse(err.response);
+        setSubmitState(SUBMIT_STATES.ERROR);
+        handleAPIErrorResponse(err.response);
         return;
       }
     }
-    this.setState({ submitState: SUBMIT_STATES.COMPLETE });
+    setSubmitState(SUBMIT_STATES.COMPLETE);
   };
 
-  renderSelect = data => {
-    const { config, reportingConfigTypes } = this.props;
-    const { invalidFields } = this.state;
+  const renderSelect = data => {
     const options = data.options?.map(userType => (
       <option value={userType.value} key={userType.value} hidden={userType.hidden}>
         {userType.label}
@@ -216,9 +214,7 @@ class ReportingConfigForm extends React.Component {
     );
   };
 
-  renderNumberField = data => {
-    const { invalidFields } = this.state;
-    const { config } = this.props;
+  const renderNumberField = data => {
     const otherProps = {
       ...data.max && { max: data.max },
       ...data.min && { min: data.min },
@@ -235,7 +231,7 @@ class ReportingConfigForm extends React.Component {
           defaultValue={config ? config[data.key] : 1}
           disabled={data.disabled}
           data-hj-suppress
-          onBlur={e => this.handleBlur(e)}
+          onBlur={e => handleBlur(e)}
           {...otherProps}
         />
         <Form.Text>{data.helpText}</Form.Text>
@@ -248,369 +244,354 @@ class ReportingConfigForm extends React.Component {
     );
   };
 
-  render() {
-    const {
-      config, availableCatalogs, reportingConfigTypes, intl,
-    } = this.props;
-    const {
-      frequency,
-      invalidFields,
-      APIErrors,
-      deliveryMethod,
-      active,
-      enableCompression,
-      submitState,
-      includeDate,
-    } = this.state;
-    const selectedCatalogs = (config?.enterpriseCustomerCatalogs || []).map(item => item.uuid);
-    const dataTypesOptions = reportingConfigTypes.dataType.map((item, index) => ({
-      key: index, label: item[1], value: item[0],
-    }));
-    const dataTypesOptionsValues = dataTypesOptions.map(item => item.value);
-    const selectedDataTypesOption = config ? [{ label: config.dataType, value: config.dataType, hidden: true }] : [];
-    return (
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          const formData = new FormData(e.target);
-          this.handleSubmit(formData, config);
-        }}
-        onChange={() => this.setState({ submitState: SUBMIT_STATES.DEFAULT })}
-      >
-        <div className="col">
-          <Form.Group>
-            <Form.Checkbox
-              className="ml-3"
-              checked={active}
-              onChange={() => this.setState(prevState => ({ active: !prevState.active }))}
-            >
-              <FormattedMessage
-                id="admin.portal.reporting.config.active"
-                defaultMessage="Active"
-                description="Checkbox label for whether the reporting configuration is active"
-              />
-            </Form.Checkbox>
-          </Form.Group>
-        </div>
-        <div className="row">
-          <div className="col col-6">
-            {this.renderSelect({
-              key: 'dataType',
-              dataTestId: 'data-type-select',
-              helpText: intl.formatMessage({
-                id: 'admin.portal.reporting.config.data.type.help',
-                defaultMessage: 'The type of data this report should contain. If this is an old report, you will not be able to change this field, and should create a new report',
-                description: 'Help text for the data type field in the reporting configuration form',
-              }),
-              label: intl.formatMessage({
-                id: 'admin.portal.reporting.config.dataType',
-                defaultMessage: 'Data Type',
-                description: 'Label for the data type field in the reporting configuration form',
-              }),
-              options: [...dataTypesOptions, ...selectedDataTypesOption],
-              disabled: config && !dataTypesOptionsValues.includes(config.dataType),
-            })}
-            {this.renderSelect({
-              key: 'reportType',
-              helpText: intl.formatMessage({
-                id: 'admin.portal.reporting.config.report.type.help',
-                defaultMessage: 'The type this report should be sent as, e.g. CSV',
-                description: 'Help text for the report type field in the reporting configuration form',
-              }),
-              label: intl.formatMessage({
-                id: 'admin.portal.reporting.config.report.type',
-                defaultMessage: 'Report Type',
-                description: 'Label for the report type field in the reporting configuration form',
-              }),
-              options: reportingConfigTypes.reportType.map(item => ({ label: item[1], value: item[0] })),
-            })}
-          </div>
-          <div className="col col-6">
-            {this.renderSelect({
-              key: 'deliveryMethod',
-              dataTestId: 'delivery-method-select',
-              helpText: intl.formatMessage({
-                id: 'admin.portal.reporting.config.delivery.method.help',
-                defaultMessage: 'The method in which the data should be sent',
-                description: 'Help text for the delivery method field in the reporting configuration form',
-              }),
-              label: intl.formatMessage({
-                id: 'admin.portal.reporting.config.delivery.method.field',
-                defaultMessage: 'Delivery Method',
-                description: 'Label for the delivery method field in the reporting configuration form',
-              }),
-              options: reportingConfigTypes.deliveryMethod.map(item => ({ label: item[1], value: item[0] })),
-              onChange: event => this.setState({ deliveryMethod: event.target.value }),
-              isInvalid: !!APIErrors.deliveryMethod,
-              invalidMessage: APIErrors.deliveryMethod,
-            })}
-            {this.renderSelect({
-              key: 'frequency',
-              dataTestId: 'frequency-select',
-              helpText: intl.formatMessage({
-                id: 'admin.portal.reporting.config.frequency.help',
-                defaultMessage: 'The frequency interval (daily, weekly, or monthly) that the report should be sent',
-                description: 'Help text for the frequency field in the reporting configuration form',
-              }),
-              label: intl.formatMessage({
-                id: 'admin.portal.reporting.config.frequency.1',
-                defaultMessage: 'Frequency',
-                description: 'Label for the frequency field in the reporting configuration form',
-              }),
-              options: reportingConfigTypes.frequency.map(item => ({ label: item[1], value: item[0] })),
-              defaultValue: frequency,
-              onChange: event => this.setState({ frequency: event.target.value }),
-            })}
-          </div>
-        </div>
-        <div className="row">
-          <div className="col">
-            {this.renderNumberField({
-              key: 'dayOfMonth',
-              helpText: intl.formatMessage({
-                id: 'admin.portal.reporting.config.day.of.month.help',
-                defaultMessage: 'The day of the month to send the report. This field is required and only valid when the frequency is monthly',
-                description: 'Help text for the day of the month field in the reporting configuration form',
-              }),
-              isInvalid: frequency === 'monthly' && invalidFields.dayOfMonth,
-              label: intl.formatMessage({
-                id: 'admin.portal.reporting.config.day.of.month',
-                defaultMessage: 'Day of Month',
-                description: 'Label for the day of the month field in the reporting configuration form',
-              }),
-              max: MONTHLY_MAX,
-              min: MONTHLY_MIN,
-              disabled: !(frequency === 'monthly'),
-              onBlur: event => this.handleBlur(event),
-            })}
-          </div>
-          <div className="col">
-            {this.renderSelect({
-              key: 'dayOfWeek',
-              helpText: intl.formatMessage({
-                id: 'admin.portal.reporting.config.day.of.week.help',
-                defaultMessage: 'The day of the week to send the report. This field is required and only valid when the frequency is weekly',
-                description: 'Help text for the day of the week field in the reporting configuration form',
-              }),
-              label: intl.formatMessage({
-                id: 'admin.portal.reporting.config.day.of.week',
-                defaultMessage: 'Day of Week',
-                description: 'Label for the day of the week field in the reporting configuration form',
-              }),
-              options: reportingConfigTypes.dayOfWeek.map(item => ({ label: item[1], value: item[0] })),
-              disabled: !(frequency === 'weekly'),
-            })}
-          </div>
-          <div className="col">
-            {this.renderNumberField({
-              key: 'hourOfDay',
-              id: 'hourOfDay',
-              helpText: intl.formatMessage({
-                id: 'admin.portal.reporting.config.hour.of.day.help',
-                defaultMessage: 'The hour of the day to send the report, in Eastern Standard Time (EST). This is required for all frequency settings',
-                description: 'Help text for the hour of the day field in the reporting configuration form',
-              }),
-              invalidMessage: 'Required for all frequency types',
-              isInvalid: invalidFields.hourOfDay,
-              min: 0,
-              label: intl.formatMessage({
-                id: 'admin.portal.reporting.config.hour.of.day',
-                defaultMessage: 'Hour of Day',
-                description: 'Label for the hour of the day field in the reporting configuration form',
-              }),
-            })}
-          </div>
-        </div>
-        <Form.Group
-          isInvalid={!!APIErrors.pgpEncryptionKey}
-        >
-          <Form.Label>
-            <FormattedMessage
-              id="admin.portal.reporting.config.pgp.encryption.ke"
-              defaultMessage="PGP Encryption Key"
-              description="Label for the PGP Encryption Key field in the reporting configuration form"
-            />
-          </Form.Label>
-          <Form.Control
-            as="textarea"
-            defaultValue={config ? config.pgpEncryptionKey : undefined}
-            data-hj-suppress
-            onBlur={e => this.handleBlur(e)}
-          />
-          <Form.Text>
-            <FormattedMessage
-              id="admin.portal.reporting.config.pgp.encryption.key.help"
-              defaultMessage="The key for encryption, if PGP encrypted file is required"
-              description="Help text for the PGP Encryption Key field in the reporting configuration form"
-            />
-          </Form.Text>
-          {!!APIErrors.pgpEncryptionKey && (
-            <Form.Control.Feedback type="invalid">
-              {APIErrors.pgpEncryptionKey}
-            </Form.Control.Feedback>
-          )}
-        </Form.Group>
-        {deliveryMethod === 'email' && (
-          <EmailDeliveryMethodForm
-            config={config}
-            invalidFields={invalidFields}
-            handleBlur={this.handleBlur}
-          />
-        )}
-        {deliveryMethod === 'sftp' && (
-          <SFTPDeliveryMethodForm
-            config={config}
-            invalidFields={invalidFields}
-            handleBlur={this.handleBlur}
-          />
-        )}
-        <Form.Group
-          isInvalid={!!APIErrors.enableCompression}
-        >
-          <Form.Label>
-            <FormattedMessage
-              id="admin.portal.reporting.config.enable.compression"
-              defaultMessage="Enable Compression"
-              description="Label for the Enable Compression field in the reporting configuration form"
-            />
-          </Form.Label>
-          <Form.Checkbox
-            data-testid="compressionCheckbox"
-            className="ml-3"
-            checked={enableCompression}
-            onChange={() => this.setState(prevState => ({ enableCompression: !prevState.enableCompression }))}
-          />
-          <Form.Text>
-            <FormattedMessage
-              id="admin.portal.reporting.config.enable.compression.help"
-              defaultMessage="Specifies whether report should be compressed. Without compression files will not be password protected or encrypted."
-              description="Help text for the Enable Compression field in the reporting configuration form"
-            />
-          </Form.Text>
-          {!!APIErrors.enableCompression && (
-            <Form.Control.Feedback type="invalid">
-              {APIErrors.enableCompression}
-            </Form.Control.Feedback>
-          )}
-        </Form.Group>
+  const selectedCatalogs = (config?.enterpriseCustomerCatalogs || []).map(item => item.uuid);
+  const dataTypesOptions = reportingConfigTypes.dataType.map((item, index) => ({
+    key: index, label: item[1], value: item[0],
+  }));
+  const dataTypesOptionsValues = dataTypesOptions.map(item => item.value);
+  const selectedDataTypesOption = config ? [{ label: config.dataType, value: config.dataType, hidden: true }] : [];
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        handleSubmit(formData, config);
+      }}
+      onChange={() => setSubmitState(SUBMIT_STATES.DEFAULT)}
+    >
+      <div className="col">
         <Form.Group>
-          <Form.Label>
-            <FormattedMessage
-              id="admin.portal.reporting.config.include.date"
-              defaultMessage="Include Date"
-              description="Label for the Include Date field in the reporting configuration form"
-            />
-          </Form.Label>
           <Form.Checkbox
-            data-testid="includeDateCheckbox"
             className="ml-3"
-            checked={includeDate}
-            onChange={() => this.setState(prevState => ({ includeDate: !prevState.includeDate }))}
-          />
-          <Form.Text>
-            <FormattedMessage
-              id="admin.portal.reporting.config.include.date.option.help"
-              defaultMessage="Specifies whether the report's filename should include the date."
-              description="Help text for the Include Date field in the reporting configuration form"
-            />
-          </Form.Text>
-        </Form.Group>
-        <Form.Group controlId="enterpriseCustomerCatalogs">
-          <Form.Label>
-            <FormattedMessage
-              id="admin.portal.reporting.config.enterprise.customer.catalogs"
-              defaultMessage="Enterprise Customer Catalogs"
-              description="Label for the Enterprise Customer Catalogs field in the reporting configuration form"
-            />
-          </Form.Label>
-          <Form.Control
-            as="select"
-            name="enterpriseCustomerCatalogUuids"
-            multiple
-            defaultValue={selectedCatalogs}
+            checked={active}
+            onChange={() => setActive(prevState => !prevState)}
           >
-            {availableCatalogs && (availableCatalogs.map((item) => (
-              <option key={item.uuid} value={item.uuid}>Catalog {item.title} with UUID {item.uuid}</option>
-            )))}
-          </Form.Control>
-          <Form.Text>
             <FormattedMessage
-              id="admin.portal.reporting.config.enterprise.customer.catalogs.help"
-              defaultMessage="The catalogs that should be included in the report. No selection means all catalogs will be included."
-              description="Help text for the Enterprise Customer Catalogs field in the reporting configuration form"
+              id="admin.portal.reporting.config.active"
+              defaultMessage="Active"
+              description="Checkbox label for whether the reporting configuration is active"
             />
-          </Form.Text>
+          </Form.Checkbox>
         </Form.Group>
-        <div className="row justify-content-between align-items-center form-group">
-          <Form.Group
-            className="mb-0"
-            isInvalid={submitState === SUBMIT_STATES.ERROR}
-          >
-            <StatefulButton
-              state={submitState}
-              type="submit"
-              id="submitButton"
-              labels={{
-                default: intl.formatMessage({
-                  id: 'admin.portal.reporting.config.submit',
-                  defaultMessage: 'Submit',
-                  description: 'Label for the button when use click to submit the reporting configuration form',
-                }),
-                pending: intl.formatMessage({
-                  id: 'admin.portal.reporting.config.saving',
-                  defaultMessage: 'Saving...',
-                  description: 'Label for the button when the form is being saved',
-                }),
-                complete: intl.formatMessage({
-                  id: 'admin.portal.reporting.config.complete',
-                  defaultMessage: 'Complete',
-                  description: 'Label for the button when the form is complete',
-                }),
-                error: intl.formatMessage({
-                  id: 'admin.portal.reporting.config.error',
-                  defaultMessage: 'Error',
-                  description: 'Label for the button when there is an error',
-                }),
-              }}
-              icons={{
-                default: <Icon src={Download} />,
-                pending: <Spinner animation="border" variant="light" size="sm" />,
-                complete: <Icon src={Check} />,
-                error: <Icon src={Close} />,
-              }}
-              disabledStates={[SUBMIT_STATES.PENDING]}
-              className="ml-3 col"
-              variant="primary"
-            />
-            {submitState === SUBMIT_STATES.ERROR && (
-              <Form.Control.Feedback type="invalid">
-                <FormattedMessage
-                  id="admin.portal.reporting.config.error.submitting"
-                  defaultMessage="There was an error submitting, please try again."
-                  description="Error message when there is an error submitting the reporting configuration form"
-                />
-              </Form.Control.Feedback>
-            )}
-          </Form.Group>
-          {config && (
-            <Button
-              data-testid="deleteConfigButton"
-              className="btn-outline-danger mr-3"
-              onClick={() => this.props.deleteConfig(config.uuid)}
-            >
-              <Icon src={Close} className="danger" />
-              <FormattedMessage
-                id="admin.portal.reporting.config.delete"
-                defaultMessage="Delete"
-                description="Label for the button to delete the reporting configuration form"
-              />
-            </Button>
-          )}
+      </div>
+      <div className="row">
+        <div className="col col-6">
+          {renderSelect({
+            key: 'dataType',
+            dataTestId: 'data-type-select',
+            helpText: intl.formatMessage({
+              id: 'admin.portal.reporting.config.data.type.help',
+              defaultMessage: 'The type of data this report should contain. If this is an old report, you will not be able to change this field, and should create a new report',
+              description: 'Help text for the data type field in the reporting configuration form',
+            }),
+            label: intl.formatMessage({
+              id: 'admin.portal.reporting.config.dataType',
+              defaultMessage: 'Data Type',
+              description: 'Label for the data type field in the reporting configuration form',
+            }),
+            options: [...dataTypesOptions, ...selectedDataTypesOption],
+            disabled: config && !dataTypesOptionsValues.includes(config.dataType),
+          })}
+          {renderSelect({
+            key: 'reportType',
+            helpText: intl.formatMessage({
+              id: 'admin.portal.reporting.config.report.type.help',
+              defaultMessage: 'The type this report should be sent as, e.g. CSV',
+              description: 'Help text for the report type field in the reporting configuration form',
+            }),
+            label: intl.formatMessage({
+              id: 'admin.portal.reporting.config.report.type',
+              defaultMessage: 'Report Type',
+              description: 'Label for the report type field in the reporting configuration form',
+            }),
+            options: reportingConfigTypes.reportType.map(item => ({ label: item[1], value: item[0] })),
+          })}
         </div>
-      </form>
-    );
-  }
-}
+        <div className="col col-6">
+          {renderSelect({
+            key: 'deliveryMethod',
+            dataTestId: 'delivery-method-select',
+            helpText: intl.formatMessage({
+              id: 'admin.portal.reporting.config.delivery.method.help',
+              defaultMessage: 'The method in which the data should be sent',
+              description: 'Help text for the delivery method field in the reporting configuration form',
+            }),
+            label: intl.formatMessage({
+              id: 'admin.portal.reporting.config.delivery.method.field',
+              defaultMessage: 'Delivery Method',
+              description: 'Label for the delivery method field in the reporting configuration form',
+            }),
+            options: reportingConfigTypes.deliveryMethod.map(item => ({ label: item[1], value: item[0] })),
+            onChange: event => setDeliveryMethod(event.target.value),
+            isInvalid: !!APIErrors.deliveryMethod,
+            invalidMessage: APIErrors.deliveryMethod,
+          })}
+          {renderSelect({
+            key: 'frequency',
+            dataTestId: 'frequency-select',
+            helpText: intl.formatMessage({
+              id: 'admin.portal.reporting.config.frequency.help',
+              defaultMessage: 'The frequency interval (daily, weekly, or monthly) that the report should be sent',
+              description: 'Help text for the frequency field in the reporting configuration form',
+            }),
+            label: intl.formatMessage({
+              id: 'admin.portal.reporting.config.frequency.1',
+              defaultMessage: 'Frequency',
+              description: 'Label for the frequency field in the reporting configuration form',
+            }),
+            options: reportingConfigTypes.frequency.map(item => ({ label: item[1], value: item[0] })),
+            defaultValue: frequency,
+            onChange: event => setFrequency(event.target.value),
+          })}
+        </div>
+      </div>
+      <div className="row">
+        <div className="col">
+          {renderNumberField({
+            key: 'dayOfMonth',
+            helpText: intl.formatMessage({
+              id: 'admin.portal.reporting.config.day.of.month.help',
+              defaultMessage: 'The day of the month to send the report. This field is required and only valid when the frequency is monthly',
+              description: 'Help text for the day of the month field in the reporting configuration form',
+            }),
+            isInvalid: frequency === 'monthly' && invalidFields.dayOfMonth,
+            label: intl.formatMessage({
+              id: 'admin.portal.reporting.config.day.of.month',
+              defaultMessage: 'Day of Month',
+              description: 'Label for the day of the month field in the reporting configuration form',
+            }),
+            max: MONTHLY_MAX,
+            min: MONTHLY_MIN,
+            disabled: !(frequency === 'monthly'),
+            onBlur: event => handleBlur(event),
+          })}
+        </div>
+        <div className="col">
+          {renderSelect({
+            key: 'dayOfWeek',
+            helpText: intl.formatMessage({
+              id: 'admin.portal.reporting.config.day.of.week.help',
+              defaultMessage: 'The day of the week to send the report. This field is required and only valid when the frequency is weekly',
+              description: 'Help text for the day of the week field in the reporting configuration form',
+            }),
+            label: intl.formatMessage({
+              id: 'admin.portal.reporting.config.day.of.week',
+              defaultMessage: 'Day of Week',
+              description: 'Label for the day of the week field in the reporting configuration form',
+            }),
+            options: reportingConfigTypes.dayOfWeek.map(item => ({ label: item[1], value: item[0] })),
+            disabled: !(frequency === 'weekly'),
+          })}
+        </div>
+        <div className="col">
+          {renderNumberField({
+            key: 'hourOfDay',
+            id: 'hourOfDay',
+            helpText: intl.formatMessage({
+              id: 'admin.portal.reporting.config.hour.of.day.help',
+              defaultMessage: 'The hour of the day to send the report, in Eastern Standard Time (EST). This is required for all frequency settings',
+              description: 'Help text for the hour of the day field in the reporting configuration form',
+            }),
+            invalidMessage: 'Required for all frequency types',
+            isInvalid: invalidFields.hourOfDay,
+            min: 0,
+            label: intl.formatMessage({
+              id: 'admin.portal.reporting.config.hour.of.day',
+              defaultMessage: 'Hour of Day',
+              description: 'Label for the hour of the day field in the reporting configuration form',
+            }),
+          })}
+        </div>
+      </div>
+      <Form.Group
+        isInvalid={!!APIErrors.pgpEncryptionKey}
+      >
+        <Form.Label>
+          <FormattedMessage
+            id="admin.portal.reporting.config.pgp.encryption.ke"
+            defaultMessage="PGP Encryption Key"
+            description="Label for the PGP Encryption Key field in the reporting configuration form"
+          />
+        </Form.Label>
+        <Form.Control
+          as="textarea"
+          defaultValue={config ? config.pgpEncryptionKey : undefined}
+          data-hj-suppress
+          onBlur={e => handleBlur(e)}
+        />
+        <Form.Text>
+          <FormattedMessage
+            id="admin.portal.reporting.config.pgp.encryption.key.help"
+            defaultMessage="The key for encryption, if PGP encrypted file is required"
+            description="Help text for the PGP Encryption Key field in the reporting configuration form"
+          />
+        </Form.Text>
+        {!!APIErrors.pgpEncryptionKey && (
+        <Form.Control.Feedback type="invalid">
+          {APIErrors.pgpEncryptionKey}
+        </Form.Control.Feedback>
+        )}
+      </Form.Group>
+      {deliveryMethod === 'email' && (
+      <EmailDeliveryMethodForm
+        config={config}
+        invalidFields={invalidFields}
+        handleBlur={handleBlur}
+      />
+      )}
+      {deliveryMethod === 'sftp' && (
+      <SFTPDeliveryMethodForm
+        config={config}
+        invalidFields={invalidFields}
+        handleBlur={handleBlur}
+      />
+      )}
+      <Form.Group
+        isInvalid={!!APIErrors.enableCompression}
+      >
+        <Form.Label>
+          <FormattedMessage
+            id="admin.portal.reporting.config.enable.compression"
+            defaultMessage="Enable Compression"
+            description="Label for the Enable Compression field in the reporting configuration form"
+          />
+        </Form.Label>
+        <Form.Checkbox
+          data-testid="compressionCheckbox"
+          className="ml-3"
+          checked={enableCompression}
+          onChange={() => setEnableCompression(prevState => !prevState)}
+        />
+        <Form.Text>
+          <FormattedMessage
+            id="admin.portal.reporting.config.enable.compression.help"
+            defaultMessage="Specifies whether report should be compressed. Without compression files will not be password protected or encrypted."
+            description="Help text for the Enable Compression field in the reporting configuration form"
+          />
+        </Form.Text>
+        {!!APIErrors.enableCompression && (
+        <Form.Control.Feedback type="invalid">
+          {APIErrors.enableCompression}
+        </Form.Control.Feedback>
+        )}
+      </Form.Group>
+      <Form.Group>
+        <Form.Label>
+          <FormattedMessage
+            id="admin.portal.reporting.config.include.date"
+            defaultMessage="Include Date"
+            description="Label for the Include Date field in the reporting configuration form"
+          />
+        </Form.Label>
+        <Form.Checkbox
+          data-testid="includeDateCheckbox"
+          className="ml-3"
+          checked={includeDate}
+          onChange={() => setIncludeDate(prevState => !prevState)}
+        />
+        <Form.Text>
+          <FormattedMessage
+            id="admin.portal.reporting.config.include.date.option.help"
+            defaultMessage="Specifies whether the report's filename should include the date."
+            description="Help text for the Include Date field in the reporting configuration form"
+          />
+        </Form.Text>
+      </Form.Group>
+      <Form.Group controlId="enterpriseCustomerCatalogs">
+        <Form.Label>
+          <FormattedMessage
+            id="admin.portal.reporting.config.enterprise.customer.catalogs"
+            defaultMessage="Enterprise Customer Catalogs"
+            description="Label for the Enterprise Customer Catalogs field in the reporting configuration form"
+          />
+        </Form.Label>
+        <Form.Control
+          as="select"
+          name="enterpriseCustomerCatalogUuids"
+          multiple
+          defaultValue={selectedCatalogs}
+        >
+          {availableCatalogs && (availableCatalogs.map((item) => (
+            <option key={item.uuid} value={item.uuid}>Catalog {item.title} with UUID {item.uuid}</option>
+          )))}
+        </Form.Control>
+        <Form.Text>
+          <FormattedMessage
+            id="admin.portal.reporting.config.enterprise.customer.catalogs.help"
+            defaultMessage="The catalogs that should be included in the report. No selection means all catalogs will be included."
+            description="Help text for the Enterprise Customer Catalogs field in the reporting configuration form"
+          />
+        </Form.Text>
+      </Form.Group>
+      <div className="row justify-content-between align-items-center form-group">
+        <Form.Group
+          className="mb-0"
+          isInvalid={submitState === SUBMIT_STATES.ERROR}
+        >
+          <StatefulButton
+            state={submitState}
+            type="submit"
+            id="submitButton"
+            labels={{
+              default: intl.formatMessage({
+                id: 'admin.portal.reporting.config.submit',
+                defaultMessage: 'Submit',
+                description: 'Label for the button when use click to submit the reporting configuration form',
+              }),
+              pending: intl.formatMessage({
+                id: 'admin.portal.reporting.config.saving',
+                defaultMessage: 'Saving...',
+                description: 'Label for the button when the form is being saved',
+              }),
+              complete: intl.formatMessage({
+                id: 'admin.portal.reporting.config.complete',
+                defaultMessage: 'Complete',
+                description: 'Label for the button when the form is complete',
+              }),
+              error: intl.formatMessage({
+                id: 'admin.portal.reporting.config.error',
+                defaultMessage: 'Error',
+                description: 'Label for the button when there is an error',
+              }),
+            }}
+            icons={{
+              default: <Icon src={Download} />,
+              pending: <Spinner animation="border" variant="light" size="sm" />,
+              complete: <Icon src={Check} />,
+              error: <Icon src={Close} />,
+            }}
+            disabledStates={[SUBMIT_STATES.PENDING]}
+            className="ml-3 col"
+            variant="primary"
+          />
+          {submitState === SUBMIT_STATES.ERROR && (
+          <Form.Control.Feedback type="invalid">
+            <FormattedMessage
+              id="admin.portal.reporting.config.error.submitting"
+              defaultMessage="There was an error submitting, please try again."
+              description="Error message when there is an error submitting the reporting configuration form"
+            />
+          </Form.Control.Feedback>
+          )}
+        </Form.Group>
+        {config && (
+        <Button
+          data-testid="deleteConfigButton"
+          className="btn-outline-danger mr-3"
+          onClick={() => deleteConfig(config.uuid)}
+        >
+          <Icon src={Close} className="danger" />
+          <FormattedMessage
+            id="admin.portal.reporting.config.delete"
+            defaultMessage="Delete"
+            description="Label for the button to delete the reporting configuration form"
+          />
+        </Button>
+        )}
+      </div>
+    </form>
+  );
+};
 ReportingConfigForm.defaultProps = {
   config: undefined,
   deleteConfig: undefined,
@@ -659,8 +640,6 @@ ReportingConfigForm.propTypes = {
   createConfig: PropTypes.func.isRequired,
   updateConfig: PropTypes.func,
   deleteConfig: PropTypes.func,
-  // injected
-  intl: intlShape.isRequired,
 };
 
-export default injectIntl(ReportingConfigForm);
+export default ReportingConfigForm;

--- a/src/components/RequestCodesPage/RequestCodesForm.jsx
+++ b/src/components/RequestCodesPage/RequestCodesForm.jsx
@@ -4,7 +4,7 @@ import { Field, reduxForm } from 'redux-form';
 import { Link, Navigate } from 'react-router-dom';
 import { Alert, Button, Spinner } from '@openedx/paragon';
 import { Error } from '@openedx/paragon/icons';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import RenderField from '../RenderField';
 
@@ -13,21 +13,21 @@ import {
 } from '../../utils';
 import messages from './messages';
 
-class RequestCodesForm extends React.Component {
-  constructor(props) {
-    super(props);
-    this.renderRedirect = this.renderRedirect.bind(this);
-  }
+const RequestCodesForm = ({
+  url,
+  error = null,
+  handleSubmit,
+  submitting,
+  invalid,
+  submitSucceeded,
+  submitFailed,
+}) => {
+  const intl = useIntl();
+  // Remove `/request` from the url so it renders Code Management page again
+  const getPathToCodeManagement = () => url.split('/').slice(0, -1).join('/');
 
-  getPathToCodeManagement() {
-    const { url } = this.props;
-
-    // Remove `/request` from the url so it renders Code Management page again
-    return url.split('/').slice(0, -1).join('/');
-  }
-
-  renderErrorMessage() {
-    const { error: { message }, intl } = this.props;
+  const renderErrorMessage = () => {
+    const { message } = error;
 
     return (
       <Alert
@@ -39,111 +39,93 @@ class RequestCodesForm extends React.Component {
         <p>{intl.formatMessage(messages.errorRetry)} {message}</p>
       </Alert>
     );
-  }
+  };
 
-  renderRedirect() {
-    return (
-      <Navigate
-        to={this.getPathToCodeManagement()}
-        state={{ hasRequestedCodes: true }}
-        replace
-      />
-    );
-  }
+  const renderRedirect = () => (
+    <Navigate
+      to={getPathToCodeManagement()}
+      state={{ hasRequestedCodes: true }}
+      replace
+    />
+  );
 
-  render() {
-    const {
-      handleSubmit,
-      submitting,
-      invalid,
-      submitSucceeded,
-      submitFailed,
-      error,
-      intl,
-    } = this.props;
-
-    return (
-      <>
-        {submitFailed && error && this.renderErrorMessage()}
-        <div className="request-codes-form row">
-          <div className="col-12 col-md-6 col-lg-4">
-            <form onSubmit={handleSubmit}>
-              <Field
-                name="emailAddress"
-                className="emailAddress"
-                type="email"
-                component={RenderField}
-                label={(
-                  <>
-                    {intl.formatMessage(messages.emailLabel)}
-                    <span className="required">*</span>
-                  </>
-                )}
-                validate={[isRequired, isValidEmail]}
-                required
-                data-hj-suppress
-              />
-              <Field
-                name="enterpriseName"
-                className="enterpriseName"
-                type="text"
-                component={RenderField}
-                label={(
-                  <>
-                    {intl.formatMessage(messages.companyLabel)}
-                    <span className="required">*</span>
-                  </>
-                )}
-                validate={[isRequired]}
-                required
-                disabled
-                data-hj-suppress
-              />
-              <Field
-                name="numberOfCodes"
-                className="numberOfCodes"
-                type="number"
-                component={RenderField}
-                label={intl.formatMessage(messages.numberOfCodesLabel)}
-                validate={[isNotValidNumberString]}
-                data-hj-suppress
-              />
-              <Field
-                name="notes"
-                className="notes"
-                type="text"
-                component={RenderField}
-                label={intl.formatMessage(messages.notesLabel)}
-                validate={[maxLength512]}
-                data-hj-suppress
-              />
-              <Button
-                type="submit"
-                disabled={invalid || submitting}
-                className="btn-primary"
-              >
+  return (
+    <>
+      {submitFailed && error && renderErrorMessage()}
+      <div className="request-codes-form row">
+        <div className="col-12 col-md-6 col-lg-4">
+          <form onSubmit={handleSubmit}>
+            <Field
+              name="emailAddress"
+              className="emailAddress"
+              type="email"
+              component={RenderField}
+              label={(
                 <>
-                  {submitting && <Spinner animation="border" className="mr-2" variant="light" size="sm" />}
-                  {intl.formatMessage(messages.submitButton)}
+                  {intl.formatMessage(messages.emailLabel)}
+                  <span className="required">*</span>
                 </>
-              </Button>
-              <Link
-                className="btn btn-link ml-3 form-cancel-btn"
-                to={this.getPathToCodeManagement()}
-              >
-                {intl.formatMessage(messages.cancelButton)}
-              </Link>
-            </form>
-          </div>
+                )}
+              validate={[isRequired, isValidEmail]}
+              required
+              data-hj-suppress
+            />
+            <Field
+              name="enterpriseName"
+              className="enterpriseName"
+              type="text"
+              component={RenderField}
+              label={(
+                <>
+                  {intl.formatMessage(messages.companyLabel)}
+                  <span className="required">*</span>
+                </>
+                )}
+              validate={[isRequired]}
+              required
+              disabled
+              data-hj-suppress
+            />
+            <Field
+              name="numberOfCodes"
+              className="numberOfCodes"
+              type="number"
+              component={RenderField}
+              label={intl.formatMessage(messages.numberOfCodesLabel)}
+              validate={[isNotValidNumberString]}
+              data-hj-suppress
+            />
+            <Field
+              name="notes"
+              className="notes"
+              type="text"
+              component={RenderField}
+              label={intl.formatMessage(messages.notesLabel)}
+              validate={[maxLength512]}
+              data-hj-suppress
+            />
+            <Button
+              type="submit"
+              disabled={invalid || submitting}
+              className="btn-primary"
+            >
+              <>
+                {submitting && <Spinner animation="border" className="mr-2" variant="light" size="sm" />}
+                {intl.formatMessage(messages.submitButton)}
+              </>
+            </Button>
+            <Link
+              className="btn btn-link ml-3 form-cancel-btn"
+              to={getPathToCodeManagement()}
+            >
+              {intl.formatMessage(messages.cancelButton)}
+            </Link>
+          </form>
         </div>
-        {submitSucceeded && this.renderRedirect()}
-      </>
-    );
-  }
-}
-
-RequestCodesForm.defaultProps = {
-  error: null,
+      </div>
+      {submitSucceeded && renderRedirect()}
+    </>
+  );
 };
 
 RequestCodesForm.propTypes = {
@@ -162,8 +144,6 @@ RequestCodesForm.propTypes = {
     enterpriseName: PropTypes.string.isRequired,
     numberOfCodes: PropTypes.string.isRequired,
   }).isRequired,
-  // injected
-  intl: intlShape.isRequired,
 };
 
-export default reduxForm({ form: 'request-codes-form' })(injectIntl(RequestCodesForm));
+export default reduxForm({ form: 'request-codes-form' })(RequestCodesForm);

--- a/src/components/subscriptions/licenses/LicenseAllocationHeader.jsx
+++ b/src/components/subscriptions/licenses/LicenseAllocationHeader.jsx
@@ -1,11 +1,12 @@
 import React, { useContext } from 'react';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider';
 import { SubsidyRequestsContext } from '../../subsidy-requests';
 import NewFeatureAlertBrowseAndRequest from '../../NewFeatureAlertBrowseAndRequest';
 import { SUPPORTED_SUBSIDY_TYPES } from '../../../data/constants/subsidyRequests';
 
-const LicenseAllocationHeader = ({ intl }) => {
+const LicenseAllocationHeader = () => {
+  const intl = useIntl();
   const {
     subscription,
   } = useContext(SubscriptionDetailContext);
@@ -38,8 +39,4 @@ const LicenseAllocationHeader = ({ intl }) => {
   );
 };
 
-LicenseAllocationHeader.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(LicenseAllocationHeader);
+export default LicenseAllocationHeader;


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead. In some components in order to use `useIntl()` hook we had to refactor some class components into functional components.

Files to refactor:
- src/components/subscriptions/licenses/LicenseAllocationHeader.jsx
- src/components/NewFeatureAlertBrowseAndRequest/index.jsx
- src/components/ReportingConfig/index.jsx
- src/components/ReportingConfig/ReportingConfigForm.jsx
- src/components/RequestCodesPage/RequestCodesForm.jsx

#### Support Information
Closes #1593 