### PR TITLE
Replace of injectIntl with useIntl() 4/4

### DIFF
--- a/src/components/CodeManagement/tests/ManageCodesTab.test.jsx
+++ b/src/components/CodeManagement/tests/ManageCodesTab.test.jsx
@@ -101,6 +101,46 @@ const sampleCouponData = {
 };
 
 describe('ManageCodesTabWrapper', () => {
+  describe('search functionality', () => {
+    it('clears search query and removes page parameter when search bar clear button is clicked', async () => {
+      const store = mockStore({
+        ...initialState,
+        coupons: {
+          ...initialState.coupons,
+          data: {
+            count: 1,
+            results: [sampleCouponData],
+          },
+        },
+      });
+      const user = userEvent.setup();
+
+      const { rerender } = render(<ManageCodesTabWrapper
+        store={store}
+        location={{
+          pathname: '/test',
+          search: '?page=2',
+        }}
+      />);
+
+      const searchInput = screen.getByPlaceholderText('Search by email or code...');
+      await user.type(searchInput, 'test search');
+
+      const clearButton = await screen.findByRole('button', { name: /clear/i });
+      await user.click(clearButton);
+
+      expect(searchInput.value).toBe('');
+
+      rerender(<ManageCodesTabWrapper
+        store={store}
+        location={{
+          pathname: '/test',
+          search: '',
+        }}
+      />);
+    });
+  });
+
   describe('renders', () => {
     it('renders empty results correctly', () => {
       const { container } = render(<ManageCodesTabWrapper />);

--- a/src/components/CodeReminderModal/index.jsx
+++ b/src/components/CodeReminderModal/index.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, SubmissionError } from 'redux-form';
 import {
   Button, ModalDialog, ActionRow, Spinner,
 } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import SaveTemplateButton from '../../containers/SaveTemplateButton';
 
@@ -25,55 +25,44 @@ const ERROR_MESSAGE_TITLES = {
   [MODAL_TYPES.save]: 'Could not save template',
 };
 
-export class BaseCodeReminderModal extends React.Component {
-  constructor(props) {
-    super(props);
+export const BaseCodeReminderModal = ({
+  submitFailed,
+  submitSucceeded,
+  onClose,
+  error,
+  couponId,
+  isBulkRemind,
+  selectedToggle,
+  data,
+  sendCodeReminder,
+  enableLearnerPortal,
+  enterpriseSlug,
+  title,
+  submitting,
+  handleSubmit,
+  couponDetailsTable,
+  onSuccess,
+}) => {
+  const { formatMessage } = useIntl();
 
-    this.errorMessageRef = React.createRef();
+  const [mode, setMode] = useState(REMIND_MODE);
+  const errorMessageRef = useRef(null);
 
-    this.state = {
-      mode: REMIND_MODE,
-    };
+  useEffect(() => {
+    const errorMessageElement = errorMessageRef?.current;
 
-    this.setMode = this.setMode.bind(this);
-    this.handleModalSubmit = this.handleModalSubmit.bind(this);
-    this.getNumberOfSelectedCodes = this.getNumberOfSelectedCodes.bind(this);
-  }
-
-  componentDidUpdate(prevProps) {
-    const {
-      submitFailed,
-      submitSucceeded,
-      onClose,
-      error,
-    } = this.props;
-    const {
-      mode,
-    } = this.state;
-
-    const errorMessageRef = this.errorMessageRef && this.errorMessageRef.current;
-
-    if (mode === REMIND_MODE && submitSucceeded && submitSucceeded !== prevProps.submitSucceeded) {
+    if (mode === REMIND_MODE && submitSucceeded) {
       onClose();
     }
 
-    if (submitFailed && error !== prevProps.error && errorMessageRef) {
-      // When there is an new error, focus on the error message status alert
-      errorMessageRef.focus();
+    if (submitFailed && error && errorMessageElement) {
+      // When there is a new error, focus on the error message status alert
+      errorMessageElement.focus();
     }
-  }
+  }, [submitFailed, submitSucceeded, onClose, error, mode]);
 
-  handleModalSubmit(formData) {
-    const {
-      couponId,
-      isBulkRemind,
-      selectedToggle,
-      data,
-      sendCodeReminder,
-      enableLearnerPortal,
-      enterpriseSlug,
-    } = this.props;
-    this.setMode(REMIND_MODE);
+  const handleModalSubmit = (formData) => {
+    setMode(REMIND_MODE);
 
     // Validate form data
     const emailTemplateKey = 'email-template-body';
@@ -120,21 +109,22 @@ export class BaseCodeReminderModal extends React.Component {
 
     return sendCodeReminder(couponId, options)
       .then((response) => {
-        this.props.onSuccess(response);
+        onSuccess(response);
       })
-      .catch((error) => {
+      .catch((err) => {
         throw new SubmissionError({
-          _error: [error.message],
+          _error: [err.message],
         });
       });
     /* eslint-enable no-underscore-dangle */
-  }
+  };
 
-  getNumberOfSelectedCodes() {
+  const getNumberOfSelectedCodes = () => {
     const {
-      data: { selectedCodes },
-      couponDetailsTable: { data: tableData },
-    } = this.props;
+      selectedCodes,
+    } = data;
+    const tableData = couponDetailsTable?.data;
+
     let numberOfSelectedCodes = 0;
     if (selectedCodes && selectedCodes.length) {
       numberOfSelectedCodes = selectedCodes.length;
@@ -142,28 +132,12 @@ export class BaseCodeReminderModal extends React.Component {
       numberOfSelectedCodes = tableData.count;
     }
     return numberOfSelectedCodes;
-  }
+  };
 
-  setMode(mode) {
-    this.setState({ mode });
-  }
+  const hasIndividualRemindData = () => ['code', 'email'].every(key => key in data);
 
-  hasIndividualRemindData() {
-    const { data } = this.props;
-    return ['code', 'email'].every(key => key in data);
-  }
-
-  renderBody() {
-    const {
-      data,
-      isBulkRemind,
-      intl: { formatMessage },
-      submitFailed,
-      error,
-    } = this.props;
-    const { mode } = this.state;
-
-    const numberOfSelectedCodes = this.getNumberOfSelectedCodes();
+  const renderBody = () => {
+    const numberOfSelectedCodes = getNumberOfSelectedCodes();
     const emailTemplateFields = getTemplateEmailFields(formatMessage);
     const reminderEmailTemplateFields = {
       ...emailTemplateFields,
@@ -178,12 +152,12 @@ export class BaseCodeReminderModal extends React.Component {
           <ModalError
             title={ERROR_MESSAGE_TITLES[mode]}
             errors={error}
-            ref={this.errorMessageRef}
+            ref={errorMessageRef}
           />
         )}
         <CodeDetails
           isBulkRemind={isBulkRemind}
-          hasIndividualRemindData={this.hasIndividualRemindData()}
+          hasIndividualRemindData={hasIndividualRemindData()}
           data={data}
           numberOfSelectedCodes={numberOfSelectedCodes}
         />
@@ -193,69 +167,56 @@ export class BaseCodeReminderModal extends React.Component {
         />
       </>
     );
-  }
+  };
 
-  renderTitle() {
-    return this.props.title;
-  }
+  const renderTitle = () => title;
 
-  render() {
-    const {
-      onClose,
-      submitting,
-      handleSubmit,
-    } = this.props;
-    const {
-      mode,
-    } = this.state;
-
-    return (
-      <ModalDialog
-        isOpen
-        data-testid="code-reminder-modal"
-        size="lg"
-        onClose={onClose}
-        className="code-reminder"
-        hasCloseButton
-        isOverflowVisible={false}
-      >
-        <ModalDialog.Header>
-          <ModalDialog.Title>
-            {this.renderTitle()}
-          </ModalDialog.Title>
-        </ModalDialog.Header>
-        <ModalDialog.Body>
-          {this.renderBody()}
-        </ModalDialog.Body>
-        <ModalDialog.Footer>
-          <ActionRow>
-            <ModalDialog.CloseButton variant="link">
-              Cancel
-            </ModalDialog.CloseButton>
-            <Button
-              data-testid="remind-submit-btn"
-              key="remind-submit-btn"
-              disabled={submitting}
-              className="code-remind-save-btn"
-              onClick={handleSubmit(this.handleModalSubmit)}
-            >
-              <>
-                {mode === REMIND_MODE && submitting && <Spinner animation="border" variant="primary" size="sm" />}
-                Remind
-              </>
-            </Button>,
-            <SaveTemplateButton
-              key="save-remind-template-btn"
-              templateType={REMIND_MODE}
-              setMode={this.setMode}
-              handleSubmit={handleSubmit}
-            />,
-          </ActionRow>
-        </ModalDialog.Footer>
-      </ModalDialog>
-    );
-  }
-}
+  return (
+    <ModalDialog
+      isOpen
+      data-testid="code-reminder-modal"
+      size="lg"
+      onClose={onClose}
+      className="code-reminder"
+      hasCloseButton
+      isOverflowVisible={false}
+    >
+      <ModalDialog.Header>
+        <ModalDialog.Title>
+          {renderTitle()}
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        {renderBody()}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton variant="link">
+            Cancel
+          </ModalDialog.CloseButton>
+          <Button
+            data-testid="remind-submit-btn"
+            key="remind-submit-btn"
+            disabled={submitting}
+            className="code-remind-save-btn"
+            onClick={handleSubmit(handleModalSubmit)}
+          >
+            <>
+              {mode === REMIND_MODE && submitting && <Spinner animation="border" variant="primary" size="sm" />}
+              Remind
+            </>
+          </Button>,
+          <SaveTemplateButton
+            key="save-remind-template-btn"
+            templateType={REMIND_MODE}
+            setMode={setMode}
+            handleSubmit={handleSubmit}
+          />,
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
 
 BaseCodeReminderModal.defaultProps = {
   error: null,
@@ -296,10 +257,8 @@ BaseCodeReminderModal.propTypes = {
     code: PropTypes.string,
     email: PropTypes.string,
   }),
-  // injected
-  intl: intlShape.isRequired,
 };
 
 export default reduxForm({
   form: 'code-reminder-modal-form',
-})(injectIntl(BaseCodeReminderModal));
+})(BaseCodeReminderModal);

--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { configuration } from '../../config';
 
@@ -9,92 +9,70 @@ import Img from '../Img';
 import messages from './messages';
 import './Footer.scss';
 
-class Footer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      enterpriseLogoNotFound: false,
-    };
-  }
+const Footer = ({ enterpriseLogo = null, enterpriseSlug = null, enterpriseName = null }) => {
+  const [enterpriseLogoNotFound, setEnterpriseLogoNotFound] = useState(false);
 
-  componentDidUpdate(prevProps) {
-    const { enterpriseLogo } = this.props;
-    if (enterpriseLogo && enterpriseLogo !== prevProps.enterpriseLogo) {
-      this.setState({ // eslint-disable-line react/no-did-update-set-state
-        enterpriseLogoNotFound: false,
-      });
+  const { formatMessage } = useIntl();
+
+  useEffect(() => {
+    if (enterpriseLogo) {
+      setEnterpriseLogoNotFound(false);
     }
-  }
+  }, [enterpriseLogo]);
 
-  renderEnterpriseLogo() {
-    const { enterpriseLogo, enterpriseSlug, enterpriseName } = this.props;
-    return (
-      <Link className="logo pl-4" to={`/${enterpriseSlug}`}>
-        <Img
-          src={enterpriseLogo}
-          alt={`${enterpriseName} logo`}
-          onError={() => this.setState({ enterpriseLogoNotFound: true })}
-        />
-      </Link>
-    );
-  }
+  const renderEnterpriseLogo = () => (
+    <Link className="logo pl-4" to={`/${enterpriseSlug}`}>
+      <Img
+        src={enterpriseLogo}
+        alt={`${enterpriseName} logo`}
+        onError={() => setEnterpriseLogoNotFound(true)}
+      />
+    </Link>
+  );
 
-  render() {
-    const { enterpriseLogoNotFound } = this.state;
-    const { enterpriseLogo } = this.props;
-    const { formatMessage } = this.props.intl;
-
-    return (
-      <footer className="container-fluid py-4 border-top">
-        <div className="row justify-content-between align-items-center">
-          <div className="col-xs-12 col-md-4 logo-links">
-            <Link className="logo border-right pr-4" to="/">
-              <Img src={configuration.LOGO_TRADEMARK_URL} alt="edX logo" />
-            </Link>
-            {enterpriseLogo && !enterpriseLogoNotFound && this.renderEnterpriseLogo()}
-          </div>
-          <div className="col-xs-12 col-md footer-links">
-            <nav>
-              <ul className="nav justify-content-end small">
-                <li className="nav-item border-right">
-                  <a className="nav-link px-2" href="https://www.edx.org/edx-terms-service">
-                    {formatMessage(messages.termsOfService)}
-                  </a>
-                </li>
-                <li className="nav-item border-right">
-                  <a className="nav-link px-2" href="https://www.edx.org/edx-privacy-policy">
-                    {formatMessage(messages.privacyPolicy)}
-                  </a>
-                </li>
-                <li className="nav-item">
-                  <Link
-                    className="nav-link px-2"
-                    to={configuration.ENTERPRISE_SUPPORT_URL}
-                    target="_blank"
-                  >
-                    {formatMessage(messages.support)}
-                  </Link>
-                </li>
-              </ul>
-            </nav>
-          </div>
+  return (
+    <footer className="container-fluid py-4 border-top">
+      <div className="row justify-content-between align-items-center">
+        <div className="col-xs-12 col-md-4 logo-links">
+          <Link className="logo border-right pr-4" to="/">
+            <Img src={configuration.LOGO_TRADEMARK_URL} alt="edX logo" />
+          </Link>
+          {enterpriseLogo && !enterpriseLogoNotFound && renderEnterpriseLogo()}
         </div>
-      </footer>
-    );
-  }
-}
+        <div className="col-xs-12 col-md footer-links">
+          <nav>
+            <ul className="nav justify-content-end small">
+              <li className="nav-item border-right">
+                <a className="nav-link px-2" href="https://www.edx.org/edx-terms-service">
+                  {formatMessage(messages.termsOfService)}
+                </a>
+              </li>
+              <li className="nav-item border-right">
+                <a className="nav-link px-2" href="https://www.edx.org/edx-privacy-policy">
+                  {formatMessage(messages.privacyPolicy)}
+                </a>
+              </li>
+              <li className="nav-item">
+                <Link
+                  className="nav-link px-2"
+                  to={configuration.ENTERPRISE_SUPPORT_URL}
+                  target="_blank"
+                >
+                  {formatMessage(messages.support)}
+                </Link>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  );
+};
 
 Footer.propTypes = {
   enterpriseName: PropTypes.string,
   enterpriseSlug: PropTypes.string,
   enterpriseLogo: PropTypes.string,
-  intl: intlShape.isRequired, // injected by injectIntl
 };
 
-Footer.defaultProps = {
-  enterpriseName: null,
-  enterpriseSlug: null,
-  enterpriseLogo: null,
-};
-
-export default injectIntl(Footer);
+export default Footer;

--- a/src/components/LearnerActivityTable/index.jsx
+++ b/src/components/LearnerActivityTable/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import TableContainer from '../../containers/TableContainer';
 import {
@@ -9,9 +9,9 @@ import {
 } from '../../utils';
 import EnterpriseDataApiService from '../../data/services/EnterpriseDataApiService';
 
-class LearnerActivityTable extends React.Component {
-  getTableColumns() {
-    const { activity, intl } = this.props;
+const LearnerActivityTable = ({ activity, id }) => {
+  const intl = useIntl();
+  const getTableColumns = () => {
     const tableColumns = [
       {
         label: intl.formatMessage({
@@ -100,53 +100,48 @@ class LearnerActivityTable extends React.Component {
       return tableColumns.filter(column => column.key !== 'passed_date');
     }
     return tableColumns;
-  }
+  };
 
-  formatTableData = enrollments => enrollments.map(enrollment => ({
+  const formatTableData = enrollments => enrollments.map(enrollment => ({
     ...enrollment,
     user_email: <span data-hj-suppress>{enrollment.user_email}</span>,
-    last_activity_date: i18nFormatTimestamp({ intl: this.props.intl, timestamp: enrollment.last_activity_date }),
-    course_start_date: i18nFormatTimestamp({ intl: this.props.intl, timestamp: enrollment.course_start_date }),
-    course_end_date: i18nFormatTimestamp({ intl: this.props.intl, timestamp: enrollment.course_end_date }),
+    last_activity_date: i18nFormatTimestamp({ intl, timestamp: enrollment.last_activity_date }),
+    course_start_date: i18nFormatTimestamp({ intl, timestamp: enrollment.course_start_date }),
+    course_end_date: i18nFormatTimestamp({ intl, timestamp: enrollment.course_end_date }),
     enrollment_date: i18nFormatTimestamp({
-      intl: this.props.intl, timestamp: enrollment.enrollment_date,
+      intl, timestamp: enrollment.enrollment_date,
     }),
-    passed_date: i18nFormatPassedTimestamp({ intl: this.props.intl, timestamp: enrollment.passed_date }),
+    passed_date: i18nFormatPassedTimestamp({ intl, timestamp: enrollment.passed_date }),
     user_account_creation_date: i18nFormatTimestamp({
-      intl: this.props.intl, timestamp: enrollment.user_account_creation_date,
+      intl, timestamp: enrollment.user_account_creation_date,
     }),
-    progress_status: i18nFormatProgressStatus({ intl: this.props.intl, progressStatus: enrollment.progress_status }),
+    progress_status: i18nFormatProgressStatus({ intl, progressStatus: enrollment.progress_status }),
     course_list_price: enrollment.course_list_price ? `$${enrollment.course_list_price}` : '',
     current_grade: formatPercentage({ decimal: enrollment.current_grade }),
   }));
 
-  render() {
-    const { activity, id } = this.props;
-    return (
-      <TableContainer
-        id={id}
-        className={id}
-        key={id}
-        fetchMethod={(enterpriseId, options) => EnterpriseDataApiService.fetchCourseEnrollments(
-          enterpriseId,
-          {
-            learnerActivity: activity,
-            ...options,
-          },
-        )}
-        columns={this.getTableColumns()}
-        formatData={this.formatTableData}
-        tableSortable
-      />
-    );
-  }
-}
+  return (
+    <TableContainer
+      id={id}
+      className={id}
+      key={id}
+      fetchMethod={(enterpriseId, options) => EnterpriseDataApiService.fetchCourseEnrollments(
+        enterpriseId,
+        {
+          learnerActivity: activity,
+          ...options,
+        },
+      )}
+      columns={getTableColumns()}
+      formatData={formatTableData}
+      tableSortable
+    />
+  );
+};
 
 LearnerActivityTable.propTypes = {
   id: PropTypes.string.isRequired,
   activity: PropTypes.string.isRequired,
-  // injected
-  intl: intlShape.isRequired,
 };
 
-export default injectIntl(LearnerActivityTable);
+export default LearnerActivityTable;


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead. In some components in order to use `useIntl()` hook we had to refactor some class components into functional components.

Files to refactor:
- src/components/CodeAssignmentModal/index.jsx
- src/components/CodeManagement/ManageCodesTab.jsx
- src/components/CodeReminderModal/index.jsx
- src/components/Footer/index.jsx
- src/components/LearnerActivityTable/index.jsx

#### Support Information
Closes #1594 